### PR TITLE
Improve scheduling and navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,262 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 🔨 最重要ルール - 新しいルールの追加プロセス
+
+ユーザーから今回限りではなく常に対応が必要だと思われる指示を受けた場合：
+
+1. 「これを標準のルールにしますか？」と質問する
+2. YESの回答を得た場合、CLAUDE.mdに追加ルールとして記載する
+3. 以降は標準ルールとして常に適用する
+
+このプロセスにより、プロジェクトのルールを継続的に改善していきます。
+
+## Development Commands
+
+### Build and Run
+```bash
+# Build the project
+./gradlew build
+
+# Run tests
+./gradlew test
+
+# Run instrumented tests
+./gradlew connectedAndroidTest
+
+# Clean build
+./gradlew clean
+
+# Install debug APK
+./gradlew installDebug
+```
+
+### Working Directory
+All Gradle commands should be run from the `Novel_reader/` directory.
+
+## Architecture Overview
+
+This is an Android novel reader application built with modern Android architecture patterns:
+
+### Core Architecture
+- **Pattern**: Clean Architecture + MVVM + Repository Pattern
+- **UI**: Jetpack Compose with single Activity pattern
+- **Database**: Room with migration support (currently v5)
+- **Navigation**: Custom NavigationManager with screen stack
+- **Background Work**: WorkManager for scheduled updates
+- **State**: Flow-based reactive programming
+
+### Key Components
+
+#### Application Entry Point
+- `NovelReaderApplication.kt` - Application class with singleton pattern for global database/repository access
+- `MainActivity.kt` - Single Activity hosting all Compose screens
+
+#### Data Layer
+- `NovelDatabase.kt` - Room database with 5 tables and proper migrations
+- `NovelRepository.kt` - Single repository managing all data access via DAOs
+- Entities: NovelDescEntity, EpisodeEntity, LastReadNovelEntity, UpdateQueueEntity, URLEntity
+
+#### Navigation
+- `NavigationManager.kt` - Custom navigation with sealed class hierarchy and back stack management
+- Main flow: Main → NovelList → EpisodeList → EpisodeView
+
+#### Key Screens
+- `NovelListScreen.kt` - Advanced filtering/sorting with enum-based configuration
+- `EpisodeViewScreen.kt` - WebView-based reading with JavaScript interface for progress tracking
+- `WebViewScreen.kt` - Novel site browsing with R18 content support
+
+### Important Patterns
+
+#### Dependency Injection
+Manual DI via Application singleton with lazy initialization:
+```kotlin
+val repository = NovelReaderApplication.instance.repository
+val database = NovelReaderApplication.instance.database
+```
+
+#### Data Access
+- Always use Repository, never access DAOs directly
+- Use Flow for reactive read operations
+- Use suspend functions for write operations
+
+#### Navigation
+Use NavigationManager for consistent navigation:
+```kotlin
+navigationManager.navigateTo(NavigationScreen.EpisodeList(novelId))
+```
+
+#### Settings Management
+Use `SettingsStore` for persistent configuration with DataStore.
+
+### Database Schema
+- `novels_descs` - Novel metadata with R18 support
+- `episodes` - Episode content with reading progress and bookmarks
+- `last_read_novels` - Reading history tracking
+- `update_queue` - Update notifications
+- `url_entity` - API/Web URLs with R18 site support
+
+### Special Features
+- Custom font loading and CSS generation for WebView
+- Ruby text (furigana) support for Japanese novels
+- Reading progress tracking via JavaScript bridge
+- Background update scheduling with WorkManager
+- Database synchronization with external SQLite files
+- R18 content handling with separate site configurations
+
+### Development Guidelines
+1. Always create Room migrations for schema changes
+2. Use proper Compose state management with state hoisting
+3. Follow the Repository pattern for all data operations
+4. Use NavigationManager for navigation to maintain proper back stack
+5. Handle R18 content appropriately with dialog-based site selection
+6. Maintain reading progress and bookmark functionality in EpisodeViewScreen
+
+#### Back Navigation Implementation
+**必須**: Android標準のナビゲーションバーのバックハンドラーを使用する
+
+```kotlin
+// MainActivity.kt での実装パターン
+class MainActivity : ComponentActivity() {
+    private lateinit var navigationManager: NavigationManager
+    private lateinit var backPressedCallback: OnBackPressedCallback
+    
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        // NavigationManager初期化
+        navigationManager = NavigationManager()
+        
+        // OnBackPressedCallbackの設定
+        backPressedCallback = object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (!navigationManager.navigateBack()) {
+                    finish()
+                }
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, backPressedCallback)
+        
+        // 以下setContent...
+    }
+}
+```
+
+**重要**:
+- deprecated な `onBackPressed()` は使用しない
+- `OnBackPressedDispatcher` を使用してシステムバックボタンとの統合を行う
+- NavigationManager と連携して適切なバック処理を実装する
+
+#### Filter and Sort Settings Persistence
+**必須**: リスト画面のフィルター・ソート設定は永続化し、次回起動時に復元する
+
+```kotlin
+// SettingsStore での実装パターン
+data class NovelListFilterSettings(
+    val sortField: String = "LAST_UPDATE_DATE",
+    val sortDirection: String = "DESCENDING",
+    val minRating: Int = 0,
+    val maxRating: Int = 5,
+    val hideRating5WithNoEpisodes: Boolean = false,
+    val showCompleted: Boolean = true,
+    val showOngoing: Boolean = true
+)
+
+// 設定の保存・読み込みメソッド
+suspend fun getNovelListFilterSettings(): NovelListFilterSettings { ... }
+suspend fun saveNovelListFilterSettings(settings: NovelListFilterSettings) { ... }
+```
+
+```kotlin
+// Screen での実装パターン
+@Composable
+fun NovelListScreen() {
+    val settingsStore = remember { SettingsStore(context) }
+    var sortField by remember { mutableStateOf(SortField.LAST_UPDATE_DATE) }
+    var filterSettings by remember { mutableStateOf(FilterSettings()) }
+    
+    // 設定の自動保存
+    fun saveCurrentSettings() {
+        scope.launch {
+            settingsStore.saveNovelListFilterSettings(...)
+        }
+    }
+    
+    // 起動時の設定読み込み
+    LaunchedEffect(key1 = true) {
+        val saved = settingsStore.getNovelListFilterSettings()
+        sortField = SortField.valueOf(saved.sortField)
+        // ...
+    }
+    
+    // 設定変更時の自動保存
+    LaunchedEffect(sortField, filterSettings) {
+        saveCurrentSettings()
+    }
+}
+```
+
+**重要**:
+- DataStoreを使用してフィルター・ソート設定を永続化
+- 画面起動時に保存された設定を自動読み込み
+- 設定変更時（ダイアログ適用、ボタンクリック等）に即座に保存
+- 例外処理を含めて enum 値の安全な復元を行う
+
+## 自動更新機能の実装
+
+### WorkManagerによるバックグラウンド自動更新 (実装完了)
+
+**概要**: 設定した時刻に自動でバックグラウンド更新を実行し、システム通知とアプリ内通知で結果を通知する機能
+
+**実装ファイル**:
+- `AutoUpdateWorker.kt` - WorkManagerによるバックグラウンド処理
+- `AutoUpdateScheduler.kt` - 自動更新の時刻スケジュール管理
+- `NotificationData.kt` & `NotificationStore.kt` - アプリ内通知管理
+- `NotificationDialog.kt` - 通知一覧UI
+- `MainActivity.kt` - メイン画面への通知機能統合
+- `AndroidManifest.xml` - バックグラウンド実行権限
+
+**主要機能**:
+1. **バックグラウンド自動更新**: 24時間間隔で指定時刻に実行
+2. **システム通知**: 更新結果をスマホの通知で即座表示
+3. **アプリ内通知**: 詳細な更新履歴と管理機能
+4. **通知バッジ**: メイン画面に未読通知数表示
+5. **権限管理**: WAKE_LOCK, SCHEDULE_EXACT_ALARM等の適切な権限設定
+
+**効果**: 
+- アプリ未起動・画面OFF時でもバックグラウンドで更新確認
+- 「新規X作品、更新Y作品」の詳細通知
+- 更新履歴の永続化と管理
+- 設定変更時の即座反映
+
+## R18作品判定ルール
+
+**必須**: 小説のR18判定は`rating`フィールドで行う
+
+```kotlin
+// R18判定の実装パターン
+val isR18 = novel.rating == 1
+
+// APIエンドポイント選択
+val apiUrl = if (isR18) {
+    "https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5&json"
+} else {
+    "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5&json"
+}
+
+// WebサイトURL選択
+val webUrl = if (isR18) {
+    "https://novel18.syosetu.com/$ncode/"
+} else {
+    "https://ncode.syosetu.com/$ncode/"
+}
+```
+
+**重要なルール**:
+- **rating = 1** → R18サイト（novel18.syosetu.com）
+- **rating = 2** → 一般サイト（ncode.syosetu.com）
+- R18作品の更新確認・閲覧は専用APIとサイトを使用
+- 一般作品の更新確認・閲覧は通常APIとサイトを使用
+
+このルールは全てのAPI呼び出し、URL生成、WebView表示で統一して適用すること。

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -27,6 +27,8 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
@@ -353,11 +355,32 @@ fun EpisodeViewScreen(
         
         // エピソード本文の表示
         if (episode != null) {
+            var dragAmountX by remember { mutableStateOf(0f) }
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(innerPadding)
                     .background(actualBackgroundColor)
+                    .pointerInput(episodeNo) {
+                        detectDragGestures(
+                            onDrag = { change, dragAmount ->
+                                dragAmountX += dragAmount.x
+                            },
+                            onDragEnd = {
+                                if (dragAmountX > 100f) {
+                                    saveReadingRate()
+                                    onPrevious()
+                                } else if (dragAmountX < -100f) {
+                                    saveReadingRate()
+                                    onNext()
+                                }
+                                dragAmountX = 0f
+                            },
+                            onDragCancel = {
+                                dragAmountX = 0f
+                            }
+                        )
+                    }
             ) {
                 Column(
                     modifier = Modifier

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -347,10 +347,10 @@ fun EpisodeViewScreen(
             }
         }
     ) { innerPadding ->
-        // システムバックボタンで目次に戻る
+        // システムバックボタンで直前の画面に戻る
         BackHandler {
             saveReadingRate()
-            onBackToToc()
+            onBack()
         }
         
         // エピソード本文の表示

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -271,13 +271,18 @@ when (val currentScreen = navigationManager.currentScreen) {
         EpisodeViewScreen(
             ncode = currentScreen.ncode,
             episodeNo = currentScreen.episodeNo,
-            onBack = { navigationManager.navigateBack() },
+            onBack = {
+                currentScreen.source?.let { source ->
+                    navigationManager.navigateBackTo(source)
+                } ?: navigationManager.navigateBack()
+            },
             onBackToToc = {
-                // Back to the previous screen without adding a new entry
-                if (!navigationManager.navigateBack()) {
-                    navigationManager.navigateTo(Screen.EpisodeList(currentScreen.ncode))
-                }
-
+                currentScreen.source?.let { source ->
+                    navigationManager.navigateBackTo(source)
+                    if (source !is Screen.EpisodeList) {
+                        navigationManager.navigateTo(Screen.EpisodeList(currentScreen.ncode, source))
+                    }
+                } ?: navigationManager.navigateTo(Screen.EpisodeList(currentScreen.ncode))
             },
             onPrevious = {
                 val prevEpisodeNo = currentScreen.episodeNo.toIntOrNull()?.let { it - 1 }?.toString() ?: "1"

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -273,8 +273,10 @@ when (val currentScreen = navigationManager.currentScreen) {
             episodeNo = currentScreen.episodeNo,
             onBack = { navigationManager.navigateBack() },
             onBackToToc = {
-                // 現在の ncode を使って EpisodeList に戻る
-                navigationManager.navigateTo(Screen.EpisodeList(currentScreen.ncode))
+                // Back to the previous screen without adding a new entry
+                if (!navigationManager.navigateBack()) {
+                    navigationManager.navigateTo(Screen.EpisodeList(currentScreen.ncode))
+                }
 
             },
             onPrevious = {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
@@ -36,15 +36,13 @@ class NavigationManager {
 
     // 特定の画面まで戻る
     fun navigateBackTo(screen: Screen): Boolean {
-        val index = screenStack.lastIndexOf(screen)
-        return if (index >= 0) {
-            // スタックから該当の画面まで取り出す
-            val newScreen = screenStack.removeAt(index)
-            // それ以降の画面を破棄
-            for (i in screenStack.size - 1 downTo index) {
-                screenStack.removeAt(i)
-            }
-            _currentScreen.value = newScreen
+        // 目的の画面が見つかるまでスタックを巻き戻す
+        while (screenStack.isNotEmpty() && screenStack.last() != screen) {
+            screenStack.removeAt(screenStack.lastIndex)
+        }
+
+        return if (screenStack.isNotEmpty() && screenStack.last() == screen) {
+            _currentScreen.value = screenStack.removeAt(screenStack.lastIndex)
             true
         } else {
             false

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -13,10 +13,13 @@ import androidx.work.WorkerParameters
 import com.shunlight_library.novel_reader.MainActivity
 import com.shunlight_library.novel_reader.NovelReaderApplication
 import com.shunlight_library.novel_reader.R
+import com.shunlight_library.novel_reader.SettingsStore
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
 import com.shunlight_library.novel_reader.data.AppNotification
 import com.shunlight_library.novel_reader.data.NotificationStore
 import com.shunlight_library.novel_reader.data.NotificationType
+import com.shunlight_library.novel_reader.worker.AutoUpdateScheduler
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -55,12 +58,25 @@ class AutoUpdateWorker(
             
             // 結果の処理と通知
             handleUpdateResults(updateResults)
-            
+
+            // 次回のスケジュールを再設定
+            reschedule()
+
             Log.d(TAG, "自動更新処理完了")
             Result.success()
         } catch (e: Exception) {
             Log.e(TAG, "自動更新処理中にエラーが発生", e)
+            reschedule()
             Result.failure()
+        }
+    }
+
+    private suspend fun reschedule() {
+        if (!tags.contains("manual_update")) {
+            val store = SettingsStore(applicationContext)
+            val enabled = store.autoUpdateEnabled.first()
+            val time = store.autoUpdateTime.first()
+            AutoUpdateScheduler(applicationContext).scheduleAutoUpdate(enabled, time)
         }
     }
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -303,4 +303,5 @@
 ### EpisodeView back navigation fix
 - System back now pops to the screen prior to any EpisodeView
 - Back to Table of Contents also clears stacked EpisodeViews
+- Fixed navigateBackTo logic to properly remove EpisodeView screens
 

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -295,5 +295,12 @@
 
 ## 次のタスク
 
+
 1. 他の画面でのナビゲーションバー対応確認
 2. 他のレイアウト改善の検討
+
+## 2025/6/15
+### EpisodeView back navigation fix
+- System back now pops to the screen prior to any EpisodeView
+- Back to Table of Contents also clears stacked EpisodeViews
+


### PR DESCRIPTION
## Summary
- keep backstack consistent when returning to episode list
- enable swipe gestures to change episodes
- reschedule next auto update after each run

## Testing
- `gradle test` *(fails: plugin resolution)*

------
https://chatgpt.com/codex/tasks/task_e_684e300addcc83229af21aebd122b058