### PR TITLE
Add swipe toggle setting

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -67,6 +67,7 @@ fun EpisodeViewScreen(
     var backgroundColor by remember { mutableStateOf("#FFFFFF") }
     var useDefaultBackground by remember { mutableStateOf(true) }
     var textOrientation by remember { mutableStateOf("Horizontal") }
+    var swipeEnabled by remember { mutableStateOf(true) }
 
     // カスタムフォント情報
     var customFonts by remember { mutableStateOf<List<CustomFontInfo>>(emptyList()) }
@@ -89,6 +90,7 @@ fun EpisodeViewScreen(
             backgroundColor = settingsStore.episodeBackgroundColor.first()
             useDefaultBackground = settingsStore.useDefaultBackground.first()
             textOrientation = settingsStore.textOrientation.first()
+            swipeEnabled = settingsStore.swipeEnabled.first()
 
             // カスタムフォント情報を読み込む
             customFonts = settingsStore.getAllCustomFontInfo()
@@ -362,7 +364,7 @@ fun EpisodeViewScreen(
                     .fillMaxSize()
                     .padding(innerPadding)
                     .background(actualBackgroundColor)
-                    .pointerInput(episodeNo, textOrientation) {
+                    .pointerInput(episodeNo, textOrientation, swipeEnabled) {
                         detectDragGestures(
                             onDrag = { change, dragAmount ->
                                 dragAmountX += dragAmount.x
@@ -374,7 +376,7 @@ fun EpisodeViewScreen(
                                     kotlin.math.abs(dragAmountX) > threshold &&
                                             kotlin.math.abs(dragAmountX) > kotlin.math.abs(dragAmountY)
 
-                                if (isHorizontalSwipe) {
+                                if (swipeEnabled && isHorizontalSwipe) {
                                     saveReadingRate()
                                     if (dragAmountX > 0) {
                                         onPrevious()

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
@@ -57,6 +57,7 @@ fun SettingsScreenUpdated(
     var backgroundColor by remember { mutableStateOf("White") }
     var selfServerAccess by remember { mutableStateOf(false) }
     var textOrientation by remember { mutableStateOf("Horizontal") }
+    var swipeEnabled by remember { mutableStateOf(true) }
     var selfServerPath by remember { mutableStateOf("") }
 
     // 新しい状態変数を追加
@@ -138,6 +139,7 @@ fun SettingsScreenUpdated(
             fontSize = settingsStore.fontSize.first()
             selfServerAccess = settingsStore.selfServerAccess.first()
             textOrientation = settingsStore.textOrientation.first()
+            swipeEnabled = settingsStore.swipeEnabled.first()
             selfServerPath = settingsStore.selfServerPath.first()
 
             // 表示関連の設定読み込み
@@ -432,6 +434,9 @@ fun SettingsScreenUpdated(
                                     episodeBackgroundColor = episodeBackgroundColor,
                                     useDefaultBackground = useDefaultBackground
                                 )
+
+                                // 左右スワイプ設定を保存
+                                settingsStore.saveSwipeEnabled(swipeEnabled)
 
                                 // 表示設定を保存
                                 settingsStore.saveDisplaySettings(
@@ -874,6 +879,21 @@ fun SettingsScreenUpdated(
                                 )
                         )
                     }
+                }
+
+                // 左右スワイプ切替
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("左右スワイプで話を移動")
+                    Spacer(modifier = Modifier.weight(1f))
+                    Switch(
+                        checked = swipeEnabled,
+                        onCheckedChange = { swipeEnabled = it }
+                    )
                 }
             }
             HorizontalDivider()

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -70,6 +70,9 @@ class SettingsStore(private val context: Context) {
         val EPISODE_BACKGROUND_COLOR = stringPreferencesKey("episode_background_color")
         val USE_DEFAULT_BACKGROUND = booleanPreferencesKey("use_default_background")
 
+        // 左右スワイプ機能のキー
+        val SWIPE_ENABLED = booleanPreferencesKey("swipe_enabled")
+
         // 自動更新設定のキー
         val AUTO_UPDATE_ENABLED = booleanPreferencesKey("auto_update_enabled")
         val AUTO_UPDATE_TIME = stringPreferencesKey("auto_update_time")
@@ -95,6 +98,7 @@ class SettingsStore(private val context: Context) {
     val defaultFontColor = "#000000" // 黒
     val defaultEpisodeBackgroundColor = "#F5F5DC" // クリーム色
     val defaultUseDefaultBackground = true
+    val defaultSwipeEnabled = true
 
     val defaultThemeMode = "System"
     val defaultFontFamily = "Gothic"
@@ -236,6 +240,18 @@ class SettingsStore(private val context: Context) {
         }
         .map { preferences: Preferences ->
             preferences[USE_DEFAULT_BACKGROUND] ?: defaultUseDefaultBackground
+        }
+
+    val swipeEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[SWIPE_ENABLED] ?: defaultSwipeEnabled
         }
 
     // 自動更新有効/無効の設定値を取得
@@ -419,6 +435,12 @@ class SettingsStore(private val context: Context) {
     suspend fun saveUseDefaultBackground(useDefault: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[USE_DEFAULT_BACKGROUND] = useDefault
+        }
+    }
+
+    suspend fun saveSwipeEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[SWIPE_ENABLED] = enabled
         }
     }
     suspend fun saveFontSize(size: Int) {


### PR DESCRIPTION
## Summary
- make horizontal swipe navigation optional
- persist swipe setting via `SettingsStore`
- expose toggle on the settings screen

## Testing
- `./gradlew build` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68500069c9a483228fbbf7a4f3ece04d