### PR TITLE
Add database export with novel selection

### DIFF
--- a/Novel_reader/app/src/main/AndroidManifest.xml
+++ b/Novel_reader/app/src/main/AndroidManifest.xml
@@ -46,6 +46,12 @@
                 android:label="データベース同期"
                 android:theme="@style/Theme.Novel_reader" />
 
+        <activity
+                android:name=".ui.DatabaseExportActivity"
+                android:exported="false"
+                android:label="データベース書き出し"
+                android:theme="@style/Theme.Novel_reader" />
+
         <!-- 更新サービスを追加 -->
         <service
                 android:name=".service.UpdateService"

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.isSystemInDarkTheme
 import com.shunlight_library.novel_reader.navigation.NavigationManager
 import com.shunlight_library.novel_reader.navigation.Screen
 import com.shunlight_library.novel_reader.ui.DatabaseSyncActivity
+import com.shunlight_library.novel_reader.ui.DatabaseExportActivity
 import com.shunlight_library.novel_reader.data.NotificationStore
 import com.shunlight_library.novel_reader.ui.components.NotificationDialog
 import kotlinx.coroutines.launch
@@ -348,6 +349,18 @@ when (val currentScreen = navigationManager.currentScreen) {
                 navigationManager.navigateBack()
             }
             // アクティビティが起動している間、ローディングまたは空の画面を表示
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+        }
+
+        is Screen.DatabaseExport -> {
+            val context = LocalContext.current
+            LaunchedEffect(Unit) {
+                val intent = Intent(context, DatabaseExportActivity::class.java)
+                context.startActivity(intent)
+                navigationManager.navigateBack()
+            }
             Box(modifier = Modifier.fillMaxSize()) {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
@@ -746,6 +759,14 @@ fun MainScreen(
                         text = "DB同期",
                         onClick = {
                             onNavigate(Screen.DatabaseSync)
+                        }
+                    )
+
+                    MenuButton(
+                        icon = "",
+                        text = "DB書き出し",
+                        onClick = {
+                            onNavigate(Screen.DatabaseExport)
                         }
                     )
                 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/EpisodeDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/EpisodeDao.kt
@@ -9,6 +9,9 @@ interface EpisodeDao {
     @Query("SELECT * FROM episodes WHERE ncode = :ncode ORDER BY episode_no")
     fun getEpisodesByNcode(ncode: String): Flow<List<EpisodeEntity>>
 
+    @Query("SELECT * FROM episodes WHERE ncode = :ncode ORDER BY episode_no")
+    suspend fun getEpisodesByNcodeList(ncode: String): List<EpisodeEntity>
+
     @Query("SELECT * FROM episodes WHERE ncode = :ncode AND episode_no = :episodeNo")
     suspend fun getEpisode(ncode: String, episodeNo: String): EpisodeEntity?
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/NovelDescDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/NovelDescDao.kt
@@ -9,6 +9,9 @@ interface NovelDescDao {
     @Query("SELECT * FROM novels_descs ORDER BY last_update_date DESC")
     fun getAllNovels(): Flow<List<NovelDescEntity>>
 
+    @Query("SELECT * FROM novels_descs ORDER BY last_update_date DESC")
+    suspend fun getAllNovelsList(): List<NovelDescEntity>
+
     @Query("SELECT * FROM novels_descs WHERE ncode = :ncode")
     suspend fun getNovelByNcode(ncode: String): NovelDescEntity?
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/export/DatabaseExportManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/export/DatabaseExportManager.kt
@@ -1,0 +1,100 @@
+package com.shunlight_library.novel_reader.data.export
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.sqlite.SQLiteDatabase
+import android.net.Uri
+import android.util.Log
+import com.shunlight_library.novel_reader.NovelReaderApplication
+import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
+import com.shunlight_library.novel_reader.data.entity.LastReadNovelEntity
+import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
+import com.shunlight_library.novel_reader.data.repository.NovelRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+
+class DatabaseExportManager(private val context: Context) {
+    companion object {
+        private const val TAG = "DatabaseExportManager"
+    }
+
+    private val repository: NovelRepository = NovelReaderApplication.getRepository()
+
+    suspend fun exportSelectedNovels(uri: Uri, ncodes: List<String>): Boolean {
+        return withContext(Dispatchers.IO) {
+            var db: SQLiteDatabase? = null
+            var tempFile: File? = null
+            try {
+                tempFile = File.createTempFile("export", ".db", context.cacheDir)
+                db = SQLiteDatabase.openOrCreateDatabase(tempFile, null)
+
+                createTables(db)
+
+                for (ncode in ncodes) {
+                    repository.getNovelByNcode(ncode)?.let { db.insert("novels_descs", null, it.toContentValues()) }
+                    repository.getEpisodesListByNcode(ncode).forEach { ep ->
+                        db.insert("episodes", null, ep.toContentValues())
+                    }
+                    repository.getLastReadByNcode(ncode)?.let { db.insert("last_read_novel", null, it.toContentValues()) }
+                }
+
+                context.contentResolver.openOutputStream(uri)?.use { output ->
+                    FileInputStream(tempFile).use { input ->
+                        input.copyTo(output)
+                    }
+                } ?: return@withContext false
+
+                true
+            } catch (e: Exception) {
+                Log.e(TAG, "export error", e)
+                false
+            } finally {
+                db?.close()
+                tempFile?.delete()
+            }
+        }
+    }
+
+    private fun createTables(db: SQLiteDatabase) {
+        db.execSQL("CREATE TABLE IF NOT EXISTS novels_descs (ncode TEXT PRIMARY KEY, title TEXT, author TEXT, Synopsis TEXT, main_tag TEXT, sub_tag TEXT, rating INTEGER, last_update_date TEXT, total_ep INTEGER, general_all_no INTEGER, updated_at TEXT, is_favorite INTEGER NOT NULL DEFAULT 0)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS idx_novels_last_update ON novels_descs (last_update_date)")
+        db.execSQL("CREATE TABLE IF NOT EXISTS episodes (ncode TEXT NOT NULL, episode_no TEXT NOT NULL, body TEXT NOT NULL, e_title TEXT, update_time TEXT, is_read INTEGER NOT NULL DEFAULT 0, is_bookmark INTEGER NOT NULL DEFAULT 0, reading_rate REAL NOT NULL DEFAULT 0.0, PRIMARY KEY(ncode, episode_no))")
+        db.execSQL("CREATE INDEX IF NOT EXISTS idx_episodes_ncode ON episodes (ncode, episode_no)")
+        db.execSQL("CREATE TABLE IF NOT EXISTS last_read_novel (ncode TEXT PRIMARY KEY, date TEXT, episode_no INTEGER)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS idx_last_read ON last_read_novel (ncode, date)")
+    }
+
+    private fun NovelDescEntity.toContentValues(): ContentValues = ContentValues().apply {
+        put("ncode", ncode)
+        put("title", title)
+        put("author", author)
+        put("Synopsis", Synopsis)
+        put("main_tag", main_tag)
+        put("sub_tag", sub_tag)
+        put("rating", rating)
+        put("last_update_date", last_update_date)
+        put("total_ep", total_ep)
+        put("general_all_no", general_all_no)
+        put("updated_at", updated_at)
+        put("is_favorite", if (is_favorite) 1 else 0)
+    }
+
+    private fun EpisodeEntity.toContentValues(): ContentValues = ContentValues().apply {
+        put("ncode", ncode)
+        put("episode_no", episode_no)
+        put("body", body)
+        put("e_title", e_title)
+        put("update_time", update_time)
+        put("is_read", if (is_read) 1 else 0)
+        put("is_bookmark", if (is_bookmark) 1 else 0)
+        put("reading_rate", reading_rate)
+    }
+
+    private fun LastReadNovelEntity.toContentValues(): ContentValues = ContentValues().apply {
+        put("ncode", ncode)
+        put("date", date)
+        put("episode_no", episode_no)
+    }
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -26,6 +26,9 @@ class NovelRepository(
 ) {
     // Novel Description関連メソッド
     val allNovels: Flow<List<NovelDescEntity>> = novelDescDao.getAllNovels()
+    suspend fun getAllNovelsList(): List<NovelDescEntity> {
+        return novelDescDao.getAllNovelsList()
+    }
 
     suspend fun getNovelByNcode(ncode: String): NovelDescEntity? {
         return novelDescDao.getNovelByNcode(ncode)
@@ -50,6 +53,10 @@ class NovelRepository(
     // Episode関連メソッド
     fun getEpisodesByNcode(ncode: String): Flow<List<EpisodeEntity>> {
         return episodeDao.getEpisodesByNcode(ncode)
+    }
+
+    suspend fun getEpisodesListByNcode(ncode: String): List<EpisodeEntity> {
+        return episodeDao.getEpisodesByNcodeList(ncode)
     }
 
     suspend fun getEpisode(ncode: String, episodeNo: String): EpisodeEntity? {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
@@ -72,6 +72,7 @@ sealed class Screen {
     object RecentlyUpdatedNovels : Screen()
     object UpdateInfo : Screen()
     object DatabaseSync : Screen()
+    object DatabaseExport : Screen()
 }
 
 /**

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/DatabaseExportActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/DatabaseExportActivity.kt
@@ -1,0 +1,130 @@
+package com.shunlight_library.novel_reader.ui
+
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.shunlight_library.novel_reader.NovelReaderApplication
+import com.shunlight_library.novel_reader.data.export.DatabaseExportManager
+import com.shunlight_library.novel_reader.data.repository.NovelRepository
+import com.shunlight_library.novel_reader.ui.theme.Novel_readerTheme
+import kotlinx.coroutines.launch
+
+class DatabaseExportActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            Novel_readerTheme {
+                DatabaseExportScreen { finish() }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DatabaseExportScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val repository: NovelRepository = NovelReaderApplication.getRepository()
+    val scope = rememberCoroutineScope()
+
+    val novels by repository.allNovels.collectAsState(initial = emptyList())
+    var selected by remember { mutableStateOf(setOf<String>()) }
+    var exportUri by remember { mutableStateOf<Uri?>(null) }
+    var isExporting by remember { mutableStateOf(false) }
+    var resultMessage by remember { mutableStateOf<String?>(null) }
+
+    val createDocumentLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/x-sqlite3")
+    ) { uri ->
+        exportUri = uri
+    }
+
+    fun toggle(ncode: String) {
+        selected = if (selected.contains(ncode)) selected - ncode else selected + ncode
+    }
+
+    fun startExport() {
+        val uri = exportUri ?: return
+        val ncodes = selected.toList()
+        isExporting = true
+        resultMessage = null
+        scope.launch {
+            val manager = DatabaseExportManager(context)
+            val success = manager.exportSelectedNovels(uri, ncodes)
+            resultMessage = if (success) "書き出し完了" else "書き出し失敗"
+            isExporting = false
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("DB書き出し") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(modifier = Modifier
+            .padding(padding)
+            .fillMaxSize()) {
+            Button(
+                onClick = { createDocumentLauncher.launch("novels_export.db") },
+                enabled = !isExporting,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(exportUri?.let { "保存先: $it" } ?: "保存先を選択")
+            }
+            LazyColumn(modifier = Modifier.weight(1f)) {
+                items(novels) { novel ->
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { toggle(novel.ncode) }
+                            .padding(8.dp)
+                    ) {
+                        Checkbox(
+                            checked = selected.contains(novel.ncode),
+                            onCheckedChange = { toggle(novel.ncode) }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(novel.title)
+                    }
+                }
+            }
+            resultMessage?.let {
+                Text(it, modifier = Modifier.padding(16.dp))
+            }
+            Button(
+                onClick = { startExport() },
+                enabled = exportUri != null && selected.isNotEmpty() && !isExporting,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Text(if (isExporting) "書き出し中..." else "書き出し")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add DAO methods to fetch lists for export
- implement `DatabaseExportManager` to save selected novels to SQLite
- add `DatabaseExportActivity` UI for selecting novels and export location
- extend navigation and main menu to open export activity
- register `DatabaseExportActivity` in manifest

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685006a1545883228e3deaafa8a1e4da