### PR TITLE
Add GitHub release check and version menu button

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -33,6 +33,8 @@ import com.shunlight_library.novel_reader.navigation.Screen
 import com.shunlight_library.novel_reader.ui.DatabaseSyncActivity
 import com.shunlight_library.novel_reader.data.NotificationStore
 import com.shunlight_library.novel_reader.ui.components.NotificationDialog
+import com.shunlight_library.novel_reader.utils.ReleaseUtils
+import com.shunlight_library.novel_reader.BuildConfig
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -94,6 +96,13 @@ class MainActivity : ComponentActivity() {
                         // 通知があることを示すフラグを設定
                         // 実際の通知表示はメイン画面で行う
                     }
+                }
+            }
+
+            // GitHubの最新リリースをバックグラウンドで確認
+            LaunchedEffect(Unit) {
+                scope.launch {
+                    ReleaseUtils.checkForNewRelease(this@MainActivity)
                 }
             }
 
@@ -747,6 +756,22 @@ fun MainScreen(
                         onClick = {
                             onNavigate(Screen.DatabaseSync)
                         }
+                    )
+                }
+            }
+
+            // アプリバージョン表示
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    MenuButton(
+                        icon = "ℹ",
+                        text = "バージョン ${BuildConfig.VERSION_NAME}",
+                        onClick = {}
                     )
                 }
             }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -78,6 +78,9 @@ class SettingsStore(private val context: Context) {
         val AUTO_UPDATE_TIME = stringPreferencesKey("auto_update_time")
         val CUSTOM_FONT_PATH = stringPreferencesKey("custom_font_path")
 
+        // GitHubリリース通知用のキー
+        val LAST_NOTIFIED_RELEASE = stringPreferencesKey("last_notified_release")
+
         // カスタムフォント管理のためのキー
         val CUSTOM_FONTS = stringSetPreferencesKey("custom_fonts")
         private const val CUSTOM_FONT_NAME_PREFIX = "custom_font_name_"
@@ -120,6 +123,7 @@ class SettingsStore(private val context: Context) {
     val defaultAutoUpdateTime = "03:00" // デフォルトは午前3時
     val defaultCustomFontPath = ""
     val defaultCustomFonts = emptySet<String>()
+    val defaultLastNotifiedRelease = ""
     
     // 小説リストフィルター設定のデフォルト値
     val defaultNovelListSortField = "LAST_UPDATE_DATE"
@@ -278,6 +282,19 @@ class SettingsStore(private val context: Context) {
         }
         .map { preferences: Preferences ->
             preferences[AUTO_UPDATE_TIME] ?: defaultAutoUpdateTime
+        }
+
+    // 最後に通知したGitHubリリースバージョンを取得
+    val lastNotifiedRelease: Flow<String> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[LAST_NOTIFIED_RELEASE] ?: defaultLastNotifiedRelease
         }
 
     // カスタムフォントIDのリストを取得するFlow
@@ -462,6 +479,19 @@ class SettingsStore(private val context: Context) {
         context.dataStore.edit { preferences ->
             preferences[CUSTOM_FONT_PATH] = path
         }
+    }
+
+    // GitHubリリース通知バージョンを保存
+    suspend fun saveLastNotifiedRelease(version: String) {
+        context.dataStore.edit { preferences ->
+            preferences[LAST_NOTIFIED_RELEASE] = version
+        }
+    }
+
+    // 最後に通知したリリースバージョンを取得
+    suspend fun getLastNotifiedRelease(): String {
+        val preferences = context.dataStore.data.first()
+        return preferences[LAST_NOTIFIED_RELEASE] ?: defaultLastNotifiedRelease
     }
     
     // 小説リストフィルター設定の取得

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
@@ -1,0 +1,102 @@
+package com.shunlight_library.novel_reader.utils
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.shunlight_library.novel_reader.BuildConfig
+import com.shunlight_library.novel_reader.R
+import com.shunlight_library.novel_reader.SettingsStore
+import com.shunlight_library.novel_reader.data.AppNotification
+import com.shunlight_library.novel_reader.data.NotificationStore
+import com.shunlight_library.novel_reader.data.NotificationType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+
+object ReleaseUtils {
+    private const val TAG = "ReleaseUtils"
+    private const val CHANNEL_ID = "novel_update_channel"
+    private const val NOTIFICATION_ID = 2001
+    private const val RELEASE_API = "https://api.github.com/repos/eightman999/Novel_reader_app/releases/latest"
+    private const val RELEASE_PAGE = "https://github.com/eightman999/Novel_reader_app/releases/latest"
+
+    private fun isNewerVersion(latest: String, current: String): Boolean {
+        val l = latest.trimStart('v', 'V').split(".")
+        val c = current.trimStart('v', 'V').split(".")
+        val size = maxOf(l.size, c.size)
+        for (i in 0 until size) {
+            val lv = l.getOrNull(i)?.toIntOrNull() ?: 0
+            val cv = c.getOrNull(i)?.toIntOrNull() ?: 0
+            if (lv != cv) return lv > cv
+        }
+        return false
+    }
+
+    suspend fun checkForNewRelease(context: Context) {
+        withContext(Dispatchers.IO) {
+            try {
+                val connection = URL(RELEASE_API).openConnection() as HttpURLConnection
+                connection.requestMethod = "GET"
+                connection.connectTimeout = 10000
+                connection.readTimeout = 10000
+                if (connection.responseCode == HttpURLConnection.HTTP_OK) {
+                    val response = BufferedReader(InputStreamReader(connection.inputStream)).use { it.readText() }
+                    val json = JSONObject(response)
+                    val tag = json.getString("tag_name")
+                    val store = SettingsStore(context)
+                    val last = store.getLastNotifiedRelease()
+                    if (isNewerVersion(tag, BuildConfig.VERSION_NAME) && last != tag) {
+                        sendSystemNotification(context, tag)
+                        NotificationStore(context).addNotification(
+                            AppNotification(
+                                id = "release_${System.currentTimeMillis()}",
+                                title = "新しいバージョン $tag",
+                                content = "GitHubに新しいリリースがあります",
+                                timestamp = System.currentTimeMillis(),
+                                type = NotificationType.INFO
+                            )
+                        )
+                        store.saveLastNotifiedRelease(tag)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "release check failed", e)
+            }
+        }
+    }
+
+    private fun sendSystemNotification(context: Context, version: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            val channel = NotificationChannel(CHANNEL_ID, "Updates", NotificationManager.IMPORTANCE_DEFAULT)
+            manager.createNotificationChannel(channel)
+        }
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(RELEASE_PAGE))
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("新しいバージョン $version")
+            .setContentText("GitHubで新しいリリースが公開されています")
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+        manager.notify(NOTIFICATION_ID, notification)
+    }
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -19,6 +19,7 @@ import com.shunlight_library.novel_reader.data.AppNotification
 import com.shunlight_library.novel_reader.data.NotificationStore
 import com.shunlight_library.novel_reader.data.NotificationType
 import com.shunlight_library.novel_reader.worker.AutoUpdateScheduler
+import com.shunlight_library.novel_reader.utils.ReleaseUtils
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -55,9 +56,12 @@ class AutoUpdateWorker(
             
             // 更新確認処理
             val updateResults = performUpdateCheck()
-            
+
             // 結果の処理と通知
             handleUpdateResults(updateResults)
+
+            // GitHubの最新リリースを確認
+            ReleaseUtils.checkForNewRelease(applicationContext)
 
             // 次回のスケジュールを再設定
             reschedule()

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -305,3 +305,10 @@
 - Back to Table of Contents also clears stacked EpisodeViews
 - Fixed navigateBackTo logic to properly remove EpisodeView screens
 
+
+## 2025/7/15
+### GitHub release check and version display
+- Notify when a new GitHub release is available during auto update and on startup
+- Added ReleaseUtils utility and DataStore key for last notified release
+- Added version info button at bottom of main menu
+- Background check runs in AutoUpdateWorker and MainActivity


### PR DESCRIPTION
## Summary
- notify when a newer GitHub release is found
- store last notified release in SettingsStore
- check for new release in AutoUpdateWorker and on startup
- show app version at bottom of main menu
- log work progress

## Testing
- `gradle build` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_687666918c008322910d98ca967dca80