### PR TITLE
Fix BuildConfig unresolved reference

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/AppInfo.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/AppInfo.kt
@@ -1,0 +1,5 @@
+package com.shunlight_library.novel_reader
+
+object AppInfo {
+    const val VERSION_NAME = "1.3.5"
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -34,7 +34,7 @@ import com.shunlight_library.novel_reader.ui.DatabaseSyncActivity
 import com.shunlight_library.novel_reader.data.NotificationStore
 import com.shunlight_library.novel_reader.ui.components.NotificationDialog
 import com.shunlight_library.novel_reader.utils.ReleaseUtils
-import com.shunlight_library.novel_reader.BuildConfig
+import com.shunlight_library.novel_reader.AppInfo
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -770,7 +770,7 @@ fun MainScreen(
                 ) {
                     MenuButton(
                         icon = "ℹ",
-                        text = "バージョン ${BuildConfig.VERSION_NAME}",
+                        text = "バージョン ${AppInfo.VERSION_NAME}",
                         onClick = {}
                     )
                 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
@@ -9,7 +9,7 @@ import android.net.Uri
 import android.os.Build
 import android.util.Log
 import androidx.core.app.NotificationCompat
-import com.shunlight_library.novel_reader.BuildConfig
+import com.shunlight_library.novel_reader.AppInfo
 import com.shunlight_library.novel_reader.R
 import com.shunlight_library.novel_reader.SettingsStore
 import com.shunlight_library.novel_reader.data.AppNotification
@@ -55,7 +55,7 @@ object ReleaseUtils {
                     val tag = json.getString("tag_name")
                     val store = SettingsStore(context)
                     val last = store.getLastNotifiedRelease()
-                    if (isNewerVersion(tag, BuildConfig.VERSION_NAME) && last != tag) {
+                    if (isNewerVersion(tag, AppInfo.VERSION_NAME) && last != tag) {
                         sendSystemNotification(context, tag)
                         NotificationStore(context).addNotification(
                             AppNotification(


### PR DESCRIPTION
## Summary
- introduce `AppInfo` with `VERSION_NAME`
- update `MainActivity` and `ReleaseUtils` to use `AppInfo`

## Testing
- `./gradlew build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68766ced166c83229cc165ae2cc6fcae