### PR TITLE
Add developer mode easter egg

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -2,6 +2,7 @@ package com.shunlight_library.novel_reader
 
 import RecentlyUpdatedNovelsScreen
 import android.content.Intent
+import android.content.Context
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -35,6 +36,12 @@ import com.shunlight_library.novel_reader.data.NotificationStore
 import com.shunlight_library.novel_reader.ui.components.NotificationDialog
 import com.shunlight_library.novel_reader.utils.ReleaseUtils
 import com.shunlight_library.novel_reader.AppInfo
+import com.shunlight_library.novel_reader.data.AppNotification
+import com.shunlight_library.novel_reader.data.NotificationType
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
 import kotlinx.coroutines.launch
 
 class MainActivity : ComponentActivity() {
@@ -276,6 +283,33 @@ when (val currentScreen = navigationManager.currentScreen) {
         )
     }
 
+    fun onVersionTap() {
+        val current = System.currentTimeMillis()
+        if (current - lastVersionTapTime < versionTapThreshold) {
+            versionTapCount++
+            if (versionTapCount == 7) {
+                versionTapCount = 0
+                scope.launch {
+                    val info = repository.getDatabaseDebugInfo()
+                    val message = "おめでとう！あなたも開発者だ！"
+                    notificationStore?.addNotification(
+                        AppNotification(
+                            id = "dev_${System.currentTimeMillis()}",
+                            title = message,
+                            content = info,
+                            timestamp = System.currentTimeMillis(),
+                            type = NotificationType.INFO
+                        )
+                    )
+                    sendDevNotification(context, message, info)
+                }
+            }
+        } else {
+            versionTapCount = 1
+        }
+        lastVersionTapTime = current
+    }
+
     is Screen.EpisodeView -> {
         EpisodeViewScreen(
             ncode = currentScreen.ncode,
@@ -428,6 +462,10 @@ fun MainScreen(
     // 通知関連の状態
     var unreadNotificationCount by remember { mutableStateOf(0) }
     var showNotificationDialog by remember { mutableStateOf(false) }
+
+    var versionTapCount by remember { mutableStateOf(0) }
+    var lastVersionTapTime by remember { mutableStateOf(0L) }
+    val versionTapThreshold = 1000
 
     // 通知データの監視
     if (notificationStore != null) {
@@ -771,7 +809,7 @@ fun MainScreen(
                     MenuButton(
                         icon = "ℹ",
                         text = "バージョン ${AppInfo.VERSION_NAME}",
-                        onClick = {}
+                        onClick = { onVersionTap() }
                     )
                 }
             }
@@ -785,4 +823,25 @@ fun MainScreen(
             onDismiss = { showNotificationDialog = false }
         )
     }
+}
+
+private const val DEV_CHANNEL_ID = "dev_info"
+private const val DEV_NOTIFICATION_ID = 2001
+
+private fun sendDevNotification(context: Context, title: String, content: String) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channel = NotificationChannel(DEV_CHANNEL_ID, "Developer", NotificationManager.IMPORTANCE_DEFAULT)
+        manager.createNotificationChannel(channel)
+    }
+    val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    val notification = NotificationCompat.Builder(context, DEV_CHANNEL_ID)
+        .setSmallIcon(R.drawable.ic_launcher_foreground)
+        .setContentTitle(title)
+        .setContentText(content)
+        .setStyle(NotificationCompat.BigTextStyle().bigText(content))
+        .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+        .setAutoCancel(true)
+        .build()
+    manager.notify(DEV_NOTIFICATION_ID, notification)
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/EpisodeDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/EpisodeDao.kt
@@ -61,6 +61,9 @@ interface EpisodeDao {
     @Query("UPDATE episodes SET reading_rate = :readingRate WHERE ncode = :ncode AND episode_no = :episodeNo")
     suspend fun updateReadingRate(ncode: String, episodeNo: String, readingRate: Float)
 
-    
+    @Query("SELECT COUNT(*) FROM episodes")
+    suspend fun getEpisodeCount(): Int
+
+
 
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/LastReadNovelDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/LastReadNovelDao.kt
@@ -23,4 +23,7 @@ interface LastReadNovelDao {
 
     @Delete
     suspend fun deleteLastRead(lastRead: LastReadNovelEntity)
+
+    @Query("SELECT COUNT(*) FROM last_read_novel")
+    suspend fun getLastReadCount(): Int
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/NovelDescDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/NovelDescDao.kt
@@ -38,4 +38,7 @@ interface NovelDescDao {
     @Query("SELECT * FROM novels_descs WHERE is_favorite = 1 ORDER BY last_update_date DESC")
     fun getFavoriteNovels(): Flow<List<NovelDescEntity>>
 
+    @Query("SELECT COUNT(*) FROM novels_descs")
+    suspend fun getNovelCount(): Int
+
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/URLEntityDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/URLEntityDao.kt
@@ -27,4 +27,7 @@ interface URLEntityDao {
 
     @Query("DELETE FROM url_entity WHERE ncode = :ncode")
     suspend fun deleteURLByNcode(ncode: String)
+
+    @Query("SELECT COUNT(*) FROM url_entity")
+    suspend fun getURLCount(): Int
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/UpdateQueueDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/UpdateQueueDao.kt
@@ -29,4 +29,7 @@ interface UpdateQueueDao {
 
     @Query("SELECT * FROM update_queue")
     suspend fun getAllUpdateQueueList(): List<UpdateQueueEntity>
+
+    @Query("SELECT COUNT(*) FROM update_queue")
+    suspend fun getUpdateQueueCount(): Int
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -231,4 +231,15 @@ class NovelRepository(
 
     val favoriteNovels: Flow<List<NovelDescEntity>> = novelDescDao.getFavoriteNovels()
 
+    suspend fun getDatabaseDebugInfo(): String {
+        return withContext(Dispatchers.IO) {
+            val novels = novelDescDao.getNovelCount()
+            val episodes = episodeDao.getEpisodeCount()
+            val lastReads = lastReadNovelDao.getLastReadCount()
+            val queues = updateQueueDao.getUpdateQueueCount()
+            val urls = urlEntityDao.getURLCount()
+            "小説数:$novels, エピソード数:$episodes, 読書履歴:$lastReads, 更新キュー:$queues, URL:$urls"
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- count records in DAOs
- expose repository method to build debug info string
- add hidden developer mode via version button tapping
- notify user with database info when unlocked

## Testing
- `./gradlew build` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687678fab3848322b6bf7136a83d94f4