### PR TITLE
Add tap navigation option

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -28,6 +28,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.style.TextOverflow
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
@@ -68,6 +69,7 @@ fun EpisodeViewScreen(
     var useDefaultBackground by remember { mutableStateOf(true) }
     var textOrientation by remember { mutableStateOf("Horizontal") }
     var swipeEnabled by remember { mutableStateOf(true) }
+    var tapEnabled by remember { mutableStateOf(false) }
 
     // カスタムフォント情報
     var customFonts by remember { mutableStateOf<List<CustomFontInfo>>(emptyList()) }
@@ -91,6 +93,7 @@ fun EpisodeViewScreen(
             useDefaultBackground = settingsStore.useDefaultBackground.first()
             textOrientation = settingsStore.textOrientation.first()
             swipeEnabled = settingsStore.swipeEnabled.first()
+            tapEnabled = settingsStore.tapEnabled.first()
 
             // カスタムフォント情報を読み込む
             customFonts = settingsStore.getAllCustomFontInfo()
@@ -366,21 +369,23 @@ fun EpisodeViewScreen(
                     .background(actualBackgroundColor)
                     .pointerInput(episodeNo, textOrientation, swipeEnabled) {
                         detectDragGestures(
-                            onDrag = { change, dragAmount ->
+                            onDrag = { _, dragAmount ->
                                 dragAmountX += dragAmount.x
                                 dragAmountY += dragAmount.y
                             },
                             onDragEnd = {
                                 val threshold = if (textOrientation == "Horizontal") 150f else 100f
                                 val isHorizontalSwipe =
-                                    kotlin.math.abs(dragAmountX) > threshold &&
-                                            kotlin.math.abs(dragAmountX) > kotlin.math.abs(dragAmountY)
+                                    abs(dragAmountX) > threshold && abs(dragAmountX) > abs(dragAmountY)
 
                                 if (swipeEnabled && isHorizontalSwipe) {
+                                    val currentEp = episodeNo.toIntOrNull() ?: 1
+                                    val canPrev = currentEp > 1
+                                    val canNext = novel?.let { currentEp < it.total_ep } ?: true
                                     saveReadingRate()
-                                    if (dragAmountX > 0) {
+                                    if (dragAmountX > 0 && canPrev) {
                                         onPrevious()
-                                    } else {
+                                    } else if (dragAmountX < 0 && canNext) {
                                         onNext()
                                     }
                                 }
@@ -392,6 +397,22 @@ fun EpisodeViewScreen(
                                 dragAmountY = 0f
                             }
                         )
+                    }
+                    .pointerInput(episodeNo, tapEnabled) {
+                        if (tapEnabled) {
+                            detectTapGestures { offset ->
+                                val width = size.width
+                                val currentEp = episodeNo.toIntOrNull() ?: 1
+                                val canPrev = currentEp > 1
+                                val canNext = novel?.let { currentEp < it.total_ep } ?: true
+                                saveReadingRate()
+                                if (offset.x < width / 2f && canPrev) {
+                                    onPrevious()
+                                } else if (offset.x >= width / 2f && canNext) {
+                                    onNext()
+                                }
+                            }
+                        }
                     }
             ) {
                 Column(

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
@@ -58,6 +58,7 @@ fun SettingsScreenUpdated(
     var selfServerAccess by remember { mutableStateOf(false) }
     var textOrientation by remember { mutableStateOf("Horizontal") }
     var swipeEnabled by remember { mutableStateOf(true) }
+    var tapEnabled by remember { mutableStateOf(false) }
     var selfServerPath by remember { mutableStateOf("") }
 
     // 新しい状態変数を追加
@@ -140,6 +141,7 @@ fun SettingsScreenUpdated(
             selfServerAccess = settingsStore.selfServerAccess.first()
             textOrientation = settingsStore.textOrientation.first()
             swipeEnabled = settingsStore.swipeEnabled.first()
+            tapEnabled = settingsStore.tapEnabled.first()
             selfServerPath = settingsStore.selfServerPath.first()
 
             // 表示関連の設定読み込み
@@ -437,6 +439,7 @@ fun SettingsScreenUpdated(
 
                                 // 左右スワイプ設定を保存
                                 settingsStore.saveSwipeEnabled(swipeEnabled)
+                                settingsStore.saveTapEnabled(tapEnabled)
 
                                 // 表示設定を保存
                                 settingsStore.saveDisplaySettings(
@@ -893,6 +896,21 @@ fun SettingsScreenUpdated(
                     Switch(
                         checked = swipeEnabled,
                         onCheckedChange = { swipeEnabled = it }
+                    )
+                }
+
+                // タップで話を移動
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("画面タップで話を移動")
+                    Spacer(modifier = Modifier.weight(1f))
+                    Switch(
+                        checked = tapEnabled,
+                        onCheckedChange = { tapEnabled = it }
                     )
                 }
             }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -73,6 +73,9 @@ class SettingsStore(private val context: Context) {
         // 左右スワイプ機能のキー
         val SWIPE_ENABLED = booleanPreferencesKey("swipe_enabled")
 
+        // タップでページ移動機能のキー
+        val TAP_ENABLED = booleanPreferencesKey("tap_enabled")
+
         // 自動更新設定のキー
         val AUTO_UPDATE_ENABLED = booleanPreferencesKey("auto_update_enabled")
         val AUTO_UPDATE_TIME = stringPreferencesKey("auto_update_time")
@@ -102,6 +105,7 @@ class SettingsStore(private val context: Context) {
     val defaultEpisodeBackgroundColor = "#F5F5DC" // クリーム色
     val defaultUseDefaultBackground = true
     val defaultSwipeEnabled = true
+    val defaultTapEnabled = false
 
     val defaultThemeMode = "System"
     val defaultFontFamily = "Gothic"
@@ -256,6 +260,18 @@ class SettingsStore(private val context: Context) {
         }
         .map { preferences: Preferences ->
             preferences[SWIPE_ENABLED] ?: defaultSwipeEnabled
+        }
+
+    val tapEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[TAP_ENABLED] ?: defaultTapEnabled
         }
 
     // 自動更新有効/無効の設定値を取得
@@ -458,6 +474,12 @@ class SettingsStore(private val context: Context) {
     suspend fun saveSwipeEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[SWIPE_ENABLED] = enabled
+        }
+    }
+
+    suspend fun saveTapEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[TAP_ENABLED] = enabled
         }
     }
     suspend fun saveFontSize(size: Int) {


### PR DESCRIPTION
## Summary
- allow navigating episodes via screen taps
- add new setting for tap-based navigation
- prevent navigating to non-existent episodes when swiping

## Testing
- `./gradlew test` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6877c6ec3c208322a0171ca345ae7ffb