### PR TITLE
Add Japanese KDoc details

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
@@ -1,7 +1,7 @@
 /*
  * eightman 2005-2025
  * Furin-lab All Rights Reserved.
- * Application class initializing database and repository.
+ * データベースとリポジトリの初期化を担当するアプリケーションクラス。
  */
 package com.shunlight_library.novel_reader
 
@@ -17,9 +17,16 @@ import kotlinx.coroutines.flow.first
 import java.util.Calendar
 import java.util.concurrent.TimeUnit
 
+/**
+ * アプリケーション全体で使用するシングルトンを初期化するクラス。
+ * Room データベースとリポジトリへの参照を提供し、
+ * WorkManager を利用して自動更新のスケジュールを設定する。
+ */
 class NovelReaderApplication : Application() {
-    // データベースとリポジトリのlazy初期化
+    /** Room データベースを遅延初期化したインスタンス */
     val database by lazy { NovelDatabase.getDatabase(this) }
+
+    /** データベースから生成されるリポジトリ */
     val repository by lazy {
         NovelRepository(
             database.episodeDao(),
@@ -39,7 +46,7 @@ class NovelReaderApplication : Application() {
         fun getRepository(): NovelRepository = instance.repository
     }
 
-    // WorkManagerのインスタンス
+    /** 自動更新ワークを管理する WorkManager インスタンス */
     private lateinit var workManager: WorkManager
 
     override fun onCreate() {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/EpisodeEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/EpisodeEntity.kt
@@ -1,7 +1,7 @@
 /*
  * eightman 2005-2025
  * Furin-lab All Rights Reserved.
- * Entity representing novel episodes.
+ * 小説のエピソード本文を保持するエンティティ。
  */
 package com.shunlight_library.novel_reader.data.entity
 
@@ -13,13 +13,25 @@ import androidx.room.Index
     primaryKeys = ["ncode", "episode_no"],
     indices = [Index(value = ["ncode", "episode_no"], name = "idx_episodes_ncode")]
 )
+/**
+ * 1 話分の情報を表すエンティティ。
+ *
+ * @property ncode このエピソードが属する小説の N コード
+ * @property episode_no エピソード番号（1 からの連番）
+ * @property body 本文 HTML
+ * @property e_title エピソードタイトル
+ * @property update_time 最終更新日時（yyyy-MM-dd HH:mm:ss）
+ * @property is_read 既読フラグ
+ * @property is_bookmark しおり登録フラグ
+ * @property reading_rate 読了率（0.0～1.0）
+ */
 data class EpisodeEntity(
     val ncode: String,
     val episode_no: String,
     val body: String,
     val e_title: String,
     val update_time: String,
-    val is_read: Boolean = false,      // 既読フラグ
-    val is_bookmark: Boolean = false,   // しおりフラグ
-    val reading_rate: Float = 0f       // 追加：読書の進行度（0.0f～1.0f）
+    val is_read: Boolean = false,
+    val is_bookmark: Boolean = false,
+    val reading_rate: Float = 0f
 )

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/LastReadNovelEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/LastReadNovelEntity.kt
@@ -1,7 +1,7 @@
 /*
  * eightman 2005-2025
  * Furin-lab All Rights Reserved.
- * Entity tracking last read episode per novel.
+ * 各小説の最終読了位置を記録するエンティティ。
  */
 package com.shunlight_library.novel_reader.data.entity
 
@@ -13,6 +13,13 @@ import androidx.room.Index
     primaryKeys = ["ncode"],
     indices = [Index(value = ["ncode", "date"], name = "idx_last_read")]
 )
+/**
+ * 最終読了エピソードを保持する。
+ *
+ * @property ncode 対象小説の N コード
+ * @property date 読了日時（ISO 8601 形式）
+ * @property episode_no 最後に読んだエピソード番号
+ */
 data class LastReadNovelEntity(
     val ncode: String,
     val date: String,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/NovelDescEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/NovelDescEntity.kt
@@ -1,7 +1,7 @@
 /*
  * eightman 2005-2025
  * Furin-lab All Rights Reserved.
- * Entity for novel metadata.
+ * 小説のメタデータを保持するエンティティ。
  */
 package com.shunlight_library.novel_reader.data.entity
 
@@ -17,11 +17,27 @@ import androidx.room.Index
         Index(value = ["is_favorite"], name = "idx_novels_favorite")
     ]
 )
+/**
+ * 小説の基本情報をまとめたエンティティ。
+ *
+ * @property ncode 小説を一意に識別する N コード
+ * @property title タイトル
+ * @property author 作者名
+ * @property Synopsis あらすじ（DB の列名に合わせて先頭大文字）
+ * @property main_tag メインタグ
+ * @property sub_tag サブタグ
+ * @property rating レーティング種別 (1=R18, 2=一般)
+ * @property last_update_date 最終更新日
+ * @property total_ep エピソード総数
+ * @property general_all_no 評価ポイント総数
+ * @property updated_at メタデータ更新日時
+ * @property is_favorite お気に入り登録フラグ
+ */
 data class NovelDescEntity(
     val ncode: String,
     val title: String,
     val author: String,
-    val Synopsis: String,  // 注意: データベース名と一致させるため頭文字大文字
+    val Synopsis: String,
     val main_tag: String,
     val sub_tag: String,
     val rating: Int,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/URLEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/URLEntity.kt
@@ -1,9 +1,8 @@
 /*
  * eightman 2005-2025
  * Furin-lab All Rights Reserved.
- * Entity mapping ncodes to URLs.
+ * N コードと各種 URL を紐付けるエンティティ。
  */
-// app/src/main/java/com/shunlight_library/novel_reader/data/entity/URLEntity.kt
 package com.shunlight_library.novel_reader.data.entity
 
 import androidx.room.Entity
@@ -14,6 +13,14 @@ import androidx.room.PrimaryKey
     tableName = "url_entity",
     indices = [Index(value = ["ncode"], name = "idx_url_entity_ncode")]
 )
+/**
+ * 小説の API URL と Web URL を保持する。
+ *
+ * @property ncode 主キーとなる N コード
+ * @property api_url 小説情報取得用 API の URL
+ * @property url 閲覧用 Web ページの URL
+ * @property is_r18 R18 作品かどうか
+ */
 data class URLEntity(
     @PrimaryKey val ncode: String,
     val api_url: String,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/UpdateQueueEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/UpdateQueueEntity.kt
@@ -1,7 +1,7 @@
 /*
  * eightman 2005-2025
  * Furin-lab All Rights Reserved.
- * Entity storing scheduled update info.
+ * 更新待ち情報を保持するエンティティ。
  */
 package com.shunlight_library.novel_reader.data.entity
 
@@ -13,6 +13,14 @@ import androidx.room.Index
     primaryKeys = ["ncode"],
     indices = [Index(value = ["update_time"], name = "idx_update_queue_time")]
 )
+/**
+ * 更新キューの 1 行を表す。
+ *
+ * @property ncode 小説の N コード
+ * @property total_ep チェック時点のエピソード総数
+ * @property general_all_no チェック時点の評価ポイント総数
+ * @property update_time 更新検出日時
+ */
 data class UpdateQueueEntity(
     val ncode: String,
     val total_ep: Int,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
@@ -1,9 +1,8 @@
 /*
  * eightman 2005-2025
  * Furin-lab All Rights Reserved.
- * Manages screen navigation stack.
+ * 画面遷移用のスタックを管理するクラス。
  */
-// NavigationManager.kt
 package com.shunlight_library.novel_reader.navigation
 
 import androidx.compose.runtime.Composable
@@ -11,25 +10,27 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 
 /**
- * 画面遷移を管理するためのクラス
+ * シンプルなバックスタック方式で画面遷移を管理するナビゲーションコントローラ。
  */
 class NavigationManager {
-    // 画面のスタック
+    /** これまでに訪れた画面のスタック */
     private val screenStack = mutableListOf<Screen>()
 
-    // 現在表示している画面
+    /** 現在表示中の画面 */
     private var _currentScreen = mutableStateOf<Screen>(Screen.Main)
     val currentScreen: Screen
         get() = _currentScreen.value
 
-    // 画面を開く
+    /** 新しい [screen] を表示し、現在の画面をスタックに積む */
     fun navigateTo(screen: Screen) {
-        // 現在の画面をスタックに追加
         screenStack.add(_currentScreen.value)
         _currentScreen.value = screen
     }
 
-    // 前の画面に戻る
+    /**
+     * 1 つ前の画面に戻る。
+     * @return 遷移できた場合は true
+     */
     fun navigateBack(): Boolean {
         return if (screenStack.isNotEmpty()) {
             _currentScreen.value = screenStack.removeAt(screenStack.size - 1)
@@ -39,7 +40,9 @@ class NavigationManager {
         }
     }
 
-    // 特定の画面まで戻る
+    /**
+     * 指定した [screen] が現れるまで戻る。
+     */
     fun navigateBackTo(screen: Screen): Boolean {
         // 目的の画面が見つかるまでスタックを巻き戻す
         while (screenStack.isNotEmpty() && screenStack.last() != screen) {
@@ -54,7 +57,9 @@ class NavigationManager {
         }
     }
 
-    // スタックをクリアして特定の画面に移動
+    /**
+     * バックスタックを全て破棄して [screen] へ遷移する。
+     */
     fun navigateClearingBackStack(screen: Screen) {
         screenStack.clear()
         _currentScreen.value = screen
@@ -62,7 +67,7 @@ class NavigationManager {
 }
 
 /**
- * アプリの画面を表す sealed class
+ * アプリ内の各画面を表現する sealed class
  */
 // navigation/Screen.kt
 sealed class Screen {
@@ -80,7 +85,7 @@ sealed class Screen {
 }
 
 /**
- * NavigationManager のインスタンスを管理する Composable 関数
+ * NavigationManager のインスタンスを Compose で保持するための関数
  */
 @Composable
 fun rememberNavigationManager(): NavigationManager {


### PR DESCRIPTION
## Summary
- add Japanese documentation to NovelReaderApplication and NavigationManager
- expand property comments in entity classes

## Testing
- `gradle test` *(fails: plugin not found due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_687b9fa2d2b88322a080d6c5167f49e5