### PR TITLE
Handle short story episodes

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -277,7 +277,7 @@ fun EpisodeListScreen(
                 // スクレイピングの実行
                 for ((index, episodeNo) in episodeNumbers.withIndex()) {
                     novel?.let {
-                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1)
+                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, generalAllNo)
 
                         if (episode != null) {
                             // データベースに保存
@@ -456,7 +456,7 @@ fun EpisodeListScreen(
                 // スクレイピングの実行
                 novel?.let {
                     for ((index, episodeNo) in redownloadTargets.withIndex()) {
-                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1)
+                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, it.general_all_no)
 
                         if (episode != null) {
                             // データベースに保存

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -137,7 +137,12 @@ fun UpdateInfoScreen(
                                 for (episodeNo in targets) {
                                     try {
                                         // NovelApiUtils.fetchEpisodeを使用
-                                        val episode = NovelApiUtils.fetchEpisode(novel.ncode, episodeNo, novel.rating == 1)
+                                        val episode = NovelApiUtils.fetchEpisode(
+                                            novel.ncode,
+                                            episodeNo,
+                                            novel.rating == 1,
+                                            novel.general_all_no
+                                        )
 
                                         if (episode != null) {
                                             // データベースに保存

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -183,7 +183,12 @@ object NovelApiUtils {
      */
     // NovelApiUtils.kt の fetchEpisode 関数を修正
     // NovelApiUtils.kt の fetchEpisode 関数を修正
-    suspend fun fetchEpisode(ncode: String, episodeNo: Int, isR18: Boolean = false): EpisodeEntity? {
+    suspend fun fetchEpisode(
+        ncode: String,
+        episodeNo: Int,
+        isR18: Boolean = false,
+        totalEpisodeCount: Int = -1
+    ): EpisodeEntity? {
         return withContext(Dispatchers.IO) {
             try {
                 val baseUrl = if (isR18) {
@@ -191,7 +196,11 @@ object NovelApiUtils {
                 } else {
                     "https://ncode.syosetu.com"
                 }
-                val url = "$baseUrl/$ncode/$episodeNo/"
+                val url = if (totalEpisodeCount == 1 && episodeNo == 1) {
+                    "$baseUrl/$ncode/"
+                } else {
+                    "$baseUrl/$ncode/$episodeNo/"
+                }
 
                 // ユーザーエージェントをランダムに設定（検出回避用）
                 val userAgents = listOf(
@@ -281,10 +290,16 @@ object NovelApiUtils {
     }
 
     // リダイレクトと複数回試行用のfetchEpisodeWithRetry関数を追加
-    suspend fun fetchEpisodeWithRetry(ncode: String, episodeNo: Int, isR18: Boolean = false, maxRetries: Int = 3): EpisodeEntity? {
+    suspend fun fetchEpisodeWithRetry(
+        ncode: String,
+        episodeNo: Int,
+        isR18: Boolean = false,
+        totalEpisodeCount: Int = -1,
+        maxRetries: Int = 3
+    ): EpisodeEntity? {
         for (attempt in 1..maxRetries) {
             try {
-                val episode = fetchEpisode(ncode, episodeNo, isR18)
+                val episode = fetchEpisode(ncode, episodeNo, isR18, totalEpisodeCount)
                 if (episode != null) {
                     return episode
                 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
@@ -329,7 +329,12 @@ class UpdateService : Service() {
                     // Check if service is still running
                     if (!isRunning) break
 
-                    val episode = NovelApiUtils.fetchEpisode(novel.ncode, episodeNo, novel.rating == 1)
+                    val episode = NovelApiUtils.fetchEpisode(
+                        novel.ncode,
+                        episodeNo,
+                        novel.rating == 1,
+                        generalAllNoValue
+                    )
 
                     if (episode != null) {
                         repository.insertEpisode(episode)
@@ -430,7 +435,12 @@ class UpdateService : Service() {
                     // Check if service is still running
                     if (!isRunning) break
 
-                    val episode = NovelApiUtils.fetchEpisode(novel.ncode, episodeNo, novel.rating == 1)
+                    val episode = NovelApiUtils.fetchEpisode(
+                        novel.ncode,
+                        episodeNo,
+                        novel.rating == 1,
+                        novel.general_all_no
+                    )
 
                     if (episode != null) {
                         repository.insertEpisode(episode)
@@ -527,7 +537,12 @@ class UpdateService : Service() {
                             // Check if service is still running
                             if (!isRunning) break
 
-                            val episode = NovelApiUtils.fetchEpisode(novel.ncode, episodeNo, novel.rating == 1)
+                            val episode = NovelApiUtils.fetchEpisode(
+                                novel.ncode,
+                                episodeNo,
+                                novel.rating == 1,
+                                queueItem.general_all_no
+                            )
 
                             if (episode != null) {
                                 repository.insertEpisode(episode)


### PR DESCRIPTION
## Summary
- allow `fetchEpisode()` to fetch the table-of-contents page when the novel only has one episode
- pass total episode count to `fetchEpisode` from callers

## Testing
- `./gradlew test` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6889dba692e48322a8c692441f12a7f6