### PR TITLE
Cache remote images for offline viewing

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
@@ -33,7 +33,8 @@ class NovelReaderApplication : Application() {
             database.novelDescDao(),
             database.lastReadNovelDao(),
             database.updateQueueDao(),
-            database.urlEntityDao()
+            database.urlEntityDao(),
+            database.imageCacheDao()
         )
     }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
 import com.shunlight_library.novel_reader.data.sync.DatabaseSyncUtils
+import com.shunlight_library.novel_reader.utils.ImageCacheUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -253,6 +254,18 @@ object NovelApiUtils {
 
                 // タイトルと本文を取得
                 val title = doc.select("h1.p-novel__title.p-novel__title--rensai").text()
+
+                // 画像をローカルキャッシュに置換
+                val imgElements = doc.select("div.p-novel__body img")
+                for (img in imgElements) {
+                    val srcUrl = img.absUrl("src")
+                    if (srcUrl.isNotEmpty()) {
+                        ImageCacheUtils.downloadAndCacheImage(srcUrl)?.let { localUri ->
+                            img.attr("src", localUri)
+                        }
+                    }
+                }
+
                 val bodyElements = doc.select("div.p-novel__body > div")
                 val body = StringBuilder()
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/ImageCacheDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/ImageCacheDao.kt
@@ -1,0 +1,22 @@
+package com.shunlight_library.novel_reader.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.shunlight_library.novel_reader.data.entity.ImageCacheEntity
+
+/**
+ * 画像キャッシュテーブルへのアクセスを提供するDAO。
+ */
+@Dao
+interface ImageCacheDao {
+    @Query("SELECT * FROM image_cache WHERE hash = :hash")
+    suspend fun getImageByHash(hash: String): ImageCacheEntity?
+
+    @Query("SELECT * FROM image_cache WHERE original_url = :url LIMIT 1")
+    suspend fun getImageByUrl(url: String): ImageCacheEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertImage(image: ImageCacheEntity)
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
@@ -16,11 +16,13 @@ import com.shunlight_library.novel_reader.data.dao.LastReadNovelDao
 import com.shunlight_library.novel_reader.data.dao.NovelDescDao
 import com.shunlight_library.novel_reader.data.dao.URLEntityDao
 import com.shunlight_library.novel_reader.data.dao.UpdateQueueDao
+import com.shunlight_library.novel_reader.data.dao.ImageCacheDao
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.LastReadNovelEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
 import com.shunlight_library.novel_reader.data.entity.URLEntity
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
+import com.shunlight_library.novel_reader.data.entity.ImageCacheEntity
 val MIGRATION_1_2 = object : Migration(1, 2) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(
@@ -70,15 +72,31 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
     }
 }
 
+val MIGRATION_6_7 = object : Migration(6, 7) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            "CREATE TABLE IF NOT EXISTS image_cache (" +
+                    "hash TEXT NOT NULL PRIMARY KEY, " +
+                    "original_url TEXT NOT NULL, " +
+                    "local_path TEXT NOT NULL, " +
+                    "mime_type TEXT NOT NULL)"
+        )
+        database.execSQL(
+            "CREATE INDEX IF NOT EXISTS idx_image_cache_hash ON image_cache (hash)"
+        )
+    }
+}
+
 @Database(
     entities = [
         EpisodeEntity::class,
         NovelDescEntity::class,
         LastReadNovelEntity::class,
         UpdateQueueEntity::class,
-        URLEntity::class
+        URLEntity::class,
+        ImageCacheEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class NovelDatabase : RoomDatabase() {
@@ -87,6 +105,7 @@ abstract class NovelDatabase : RoomDatabase() {
     abstract fun lastReadNovelDao(): LastReadNovelDao
     abstract fun updateQueueDao(): UpdateQueueDao
     abstract fun urlEntityDao(): URLEntityDao
+    abstract fun imageCacheDao(): ImageCacheDao
 
     companion object {
         @Volatile
@@ -99,7 +118,14 @@ abstract class NovelDatabase : RoomDatabase() {
                     NovelDatabase::class.java,
                     "novel_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
+                    .addMigrations(
+                        MIGRATION_1_2,
+                        MIGRATION_2_3,
+                        MIGRATION_3_4,
+                        MIGRATION_4_5,
+                        MIGRATION_5_6,
+                        MIGRATION_6_7
+                    )
                     .build()
                 INSTANCE = instance
                 instance

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/ImageCacheEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/ImageCacheEntity.kt
@@ -1,0 +1,17 @@
+package com.shunlight_library.novel_reader.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+/**
+ * 画像のキャッシュを管理するエンティティ。
+ * 画像の内容ハッシュをファイル名とし、
+ * 元URLと保存先パス、MIMEタイプを保持する。
+ */
+@Entity(tableName = "image_cache")
+data class ImageCacheEntity(
+    @PrimaryKey val hash: String,
+    val original_url: String,
+    val local_path: String,
+    val mime_type: String
+)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -10,11 +10,13 @@ import com.shunlight_library.novel_reader.data.dao.LastReadNovelDao
 import com.shunlight_library.novel_reader.data.dao.NovelDescDao
 import com.shunlight_library.novel_reader.data.dao.URLEntityDao
 import com.shunlight_library.novel_reader.data.dao.UpdateQueueDao
+import com.shunlight_library.novel_reader.data.dao.ImageCacheDao
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.LastReadNovelEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
 import com.shunlight_library.novel_reader.data.entity.URLEntity
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
+import com.shunlight_library.novel_reader.data.entity.ImageCacheEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -27,7 +29,8 @@ class NovelRepository(
     private val novelDescDao: NovelDescDao,
     private val lastReadNovelDao: LastReadNovelDao,
     private val updateQueueDao: UpdateQueueDao,
-    private val urlEntityDao: URLEntityDao
+    private val urlEntityDao: URLEntityDao,
+    private val imageCacheDao: ImageCacheDao
 ) {
     // Novel Description関連メソッド
     val allNovels: Flow<List<NovelDescEntity>> = novelDescDao.getAllNovels()
@@ -196,6 +199,19 @@ class NovelRepository(
 
     suspend fun updateReadingRate(ncode: String, episodeNo: String, readingRate: Float) {
         episodeDao.updateReadingRate(ncode, episodeNo, readingRate)
+    }
+
+    // 画像キャッシュ関連メソッド
+    suspend fun getImageByHash(hash: String): ImageCacheEntity? {
+        return imageCacheDao.getImageByHash(hash)
+    }
+
+    suspend fun getImageByUrl(url: String): ImageCacheEntity? {
+        return imageCacheDao.getImageByUrl(url)
+    }
+
+    suspend fun insertImageCache(image: ImageCacheEntity) {
+        imageCacheDao.insertImage(image)
     }
 
     suspend fun getOrCreateURL(ncode: String, isR18: Boolean = false): URLEntity {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ImageCacheUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ImageCacheUtils.kt
@@ -1,0 +1,78 @@
+package com.shunlight_library.novel_reader.utils
+
+import android.util.Log
+import com.shunlight_library.novel_reader.NovelReaderApplication
+import com.shunlight_library.novel_reader.data.entity.ImageCacheEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+
+/**
+ * 画像のダウンロードとローカルキャッシュを行うユーティリティ。
+ */
+object ImageCacheUtils {
+    private const val TAG = "ImageCacheUtils"
+
+    /**
+     * 指定されたURLの画像をダウンロードしてキャッシュし、ローカルURIを返す。
+     * 既にハッシュが存在する場合は再利用する。
+     */
+    suspend fun downloadAndCacheImage(url: String): String? {
+        val repository = NovelReaderApplication.getRepository()
+        // URL一致で既存データを確認
+        repository.getImageByUrl(url)?.let {
+            return "file://${it.local_path}"
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val connection = URL(url).openConnection() as HttpURLConnection
+                connection.connectTimeout = 10000
+                connection.readTimeout = 10000
+                connection.connect()
+
+                val mimeType = connection.contentType ?: return@withContext null
+                val bytes = connection.inputStream.use { it.readBytes() }
+
+                val hash = MessageDigest.getInstance("SHA-256")
+                    .digest(bytes)
+                    .joinToString("") { b -> "%02x".format(b) }
+
+                // ハッシュで既存キャッシュを確認
+                repository.getImageByHash(hash)?.let {
+                    return@withContext "file://${it.local_path}"
+                }
+
+                val extension = when {
+                    mimeType.contains("jpeg") || mimeType.contains("jpg") -> ".jpg"
+                    mimeType.contains("png") -> ".png"
+                    mimeType.contains("webp") -> ".webp"
+                    mimeType.contains("avif") -> ".avif"
+                    else -> return@withContext null
+                }
+
+                val context = NovelReaderApplication.getAppContext()
+                val file = File(context.filesDir, hash + extension)
+                FileOutputStream(file).use { it.write(bytes) }
+
+                repository.insertImageCache(
+                    ImageCacheEntity(
+                        hash = hash,
+                        original_url = url,
+                        local_path = file.absolutePath,
+                        mime_type = mimeType
+                    )
+                )
+
+                "file://${file.absolutePath}"
+            } catch (e: Exception) {
+                Log.e(TAG, "画像ダウンロード失敗: ${e.message}", e)
+                null
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Room table and DAO for image cache metadata and storage
- Cache episode images to app files using SHA-256-based filenames and reuse duplicates
- Replace episode HTML image sources with local file URIs

## Testing
- `./gradlew build` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c28db463d4832287095df4c37193e7