### PR TITLE
Fix version tap handler placement causing compile errors

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -291,33 +291,6 @@ when (val currentScreen = navigationManager.currentScreen) {
         )
     }
 
-    fun onVersionTap() {
-        val current = System.currentTimeMillis()
-        if (current - lastVersionTapTime < versionTapThreshold) {
-            versionTapCount++
-            if (versionTapCount == 7) {
-                versionTapCount = 0
-                scope.launch {
-                    val info = repository.getDatabaseDebugInfo()
-                    val message = "おめでとう！あなたも開発者だ！"
-                    notificationStore?.addNotification(
-                        AppNotification(
-                            id = "dev_${System.currentTimeMillis()}",
-                            title = message,
-                            content = info,
-                            timestamp = System.currentTimeMillis(),
-                            type = NotificationType.INFO
-                        )
-                    )
-                    sendDevNotification(context, message, info)
-                }
-            }
-        } else {
-            versionTapCount = 1
-        }
-        lastVersionTapTime = current
-    }
-
     is Screen.EpisodeView -> {
         EpisodeViewScreen(
             ncode = currentScreen.ncode,
@@ -474,6 +447,33 @@ fun MainScreen(
     var versionTapCount by remember { mutableStateOf(0) }
     var lastVersionTapTime by remember { mutableStateOf(0L) }
     val versionTapThreshold = 1000
+
+    fun onVersionTap() {
+        val current = System.currentTimeMillis()
+        if (current - lastVersionTapTime < versionTapThreshold) {
+            versionTapCount++
+            if (versionTapCount == 7) {
+                versionTapCount = 0
+                scope.launch {
+                    val info = repository.getDatabaseDebugInfo()
+                    val message = "おめでとう！あなたも開発者だ！"
+                    notificationStore?.addNotification(
+                        AppNotification(
+                            id = "dev_${System.currentTimeMillis()}",
+                            title = message,
+                            content = info,
+                            timestamp = System.currentTimeMillis(),
+                            type = NotificationType.INFO
+                        )
+                    )
+                    sendDevNotification(context, message, info)
+                }
+            }
+        } else {
+            versionTapCount = 1
+        }
+        lastVersionTapTime = current
+    }
 
     // 通知データの監視
     if (notificationStore != null) {


### PR DESCRIPTION
## Summary
- Move `onVersionTap` handler inside `MainScreen` so it can access UI state
- Clean up `when` navigation block by removing stray function and ensuring branches for each screen

## Testing
- `gradle build` *(fails: Plugin [id: 'com.android.application', version: '8.13.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a0b9cb788322a5da9ba9c624e60b