### PR TITLE
Add Japanese comments across utils, API and database

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -302,7 +302,10 @@ object NovelApiUtils {
         }
     }
 
-    // リダイレクトと複数回試行用のfetchEpisodeWithRetry関数を追加
+    /**
+     * リダイレクトに対応しつつエピソード取得を複数回試行する
+     * ネットワークエラー時には指定回数まで再試行を行う
+     */
     suspend fun fetchEpisodeWithRetry(
         ncode: String,
         episodeNo: Int,
@@ -327,7 +330,7 @@ object NovelApiUtils {
         return null
     }
     /**
-     * URLからncodeとR18フラグを抽出する
+     * URLからncodeとR18フラグを正規表現で解析して抽出する
      * @param url 小説のURL
      * @return Pair(ncode, isR18)、取得できなかった場合は (null, false)
      */
@@ -346,7 +349,7 @@ object NovelApiUtils {
     }
 
     /**
-     * 重複確認 - 既に小説が登録されているかどうかをチェックする
+     * 重複確認 - 既に小説が登録されているかをリポジトリでチェックする
      * @param repository リポジトリインスタンス
      * @param ncode 確認するNコード
      * @return 既に登録されている場合はtrue、そうでない場合はfalse

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
@@ -23,6 +23,10 @@ import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
 import com.shunlight_library.novel_reader.data.entity.URLEntity
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
 import com.shunlight_library.novel_reader.data.entity.ImageCacheEntity
+
+/**
+ * v1→v2のマイグレーション: 更新キュー用テーブルを作成
+ */
 val MIGRATION_1_2 = object : Migration(1, 2) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(
@@ -37,13 +41,19 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
         )
     }
 }
+/**
+ * v2→v3のマイグレーション: エピソードテーブルに既読・ブックマーク列を追加
+ */
 val MIGRATION_2_3 = object : Migration(2, 3) {
     override fun migrate(database: SupportSQLiteDatabase) {
-        // Add new columns to the episodes table
         database.execSQL("ALTER TABLE episodes ADD COLUMN is_read INTEGER NOT NULL DEFAULT 0")
         database.execSQL("ALTER TABLE episodes ADD COLUMN is_bookmark INTEGER NOT NULL DEFAULT 0")
     }
 }
+
+/**
+ * v3→v4のマイグレーション: URL情報を保存するテーブルを追加
+ */
 val MIGRATION_3_4 = object : Migration(3, 4) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(
@@ -59,12 +69,18 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
     }
 }
 
+/**
+ * v4→v5のマイグレーション: エピソードに読書進捗率を追加
+ */
 val MIGRATION_4_5 = object : Migration(4, 5) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL("ALTER TABLE episodes ADD COLUMN reading_rate REAL NOT NULL DEFAULT 0.0")
     }
 }
 
+/**
+ * v5→v6のマイグレーション: 小説テーブルにお気に入りフラグを追加
+ */
 val MIGRATION_5_6 = object : Migration(5, 6) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL("ALTER TABLE novels_descs ADD COLUMN is_favorite INTEGER NOT NULL DEFAULT 0")
@@ -72,6 +88,9 @@ val MIGRATION_5_6 = object : Migration(5, 6) {
     }
 }
 
+/**
+ * v6→v7のマイグレーション: 画像キャッシュ用テーブルを追加
+ */
 val MIGRATION_6_7 = object : Migration(6, 7) {
     override fun migrate(database: SupportSQLiteDatabase) {
         database.execSQL(
@@ -87,6 +106,9 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
     }
 }
 
+/**
+ * アプリ全体で使用するRoomデータベース定義
+ */
 @Database(
     entities = [
         EpisodeEntity::class,
@@ -111,6 +133,9 @@ abstract class NovelDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: NovelDatabase? = null
 
+        /**
+         * シングルトンとしてデータベースインスタンスを取得する
+         */
         fun getDatabase(context: Context): NovelDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
@@ -35,6 +35,12 @@ object ReleaseUtils {
     private const val RELEASE_API = "https://api.github.com/repos/eightman999/Novel_reader_app/releases/latest"
     private const val RELEASE_PAGE = "https://github.com/eightman999/Novel_reader_app/releases/latest"
 
+    /**
+     * バージョン文字列を比較して最新かどうかを判定する
+     * @param latest APIから取得した最新バージョン
+     * @param current 現在のアプリバージョン
+     * @return latestがcurrentより新しい場合はtrue
+     */
     private fun isNewerVersion(latest: String, current: String): Boolean {
         val l = latest.trimStart('v', 'V').split(".")
         val c = current.trimStart('v', 'V').split(".")
@@ -47,6 +53,10 @@ object ReleaseUtils {
         return false
     }
 
+    /**
+     * GitHub上の最新リリースをチェックし、必要に応じて通知を行う
+     * ネットワーク処理はIOスレッドで実行される
+     */
     suspend fun checkForNewRelease(context: Context) {
         withContext(Dispatchers.IO) {
             try {
@@ -80,6 +90,11 @@ object ReleaseUtils {
         }
     }
 
+    /**
+     * 新しいバージョンをシステム通知で知らせる
+     * @param context コンテキスト
+     * @param version 新しいバージョン名
+     */
     private fun sendSystemNotification(context: Context, version: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager


### PR DESCRIPTION
## Summary
- annotate release utility functions with Japanese comments
- document API retry and URL parsing helpers in Japanese
- add Japanese explanations for Room database migrations and access

## Testing
- `./gradlew test` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a18af2c48322b17557bfe99700ae