### PR TITLE
Support novel metadata from API

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -34,16 +34,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.jsoup.Jsoup
-import org.yaml.snakeyaml.Yaml
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.net.HttpURLConnection
-import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
-import java.util.zip.GZIPInputStream
 import com.shunlight_library.novel_reader.api.NovelApiUtils.fetchEpisode
 
 enum class UpdateType {
@@ -277,7 +270,7 @@ fun EpisodeListScreen(
                 // スクレイピングの実行
                 for ((index, episodeNo) in episodeNumbers.withIndex()) {
                     novel?.let {
-                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, generalAllNo)
+                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, it.noveltype)
 
                         if (episode != null) {
                             // データベースに保存
@@ -456,7 +449,7 @@ fun EpisodeListScreen(
                 // スクレイピングの実行
                 novel?.let {
                     for ((index, episodeNo) in redownloadTargets.withIndex()) {
-                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, it.general_all_no)
+                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, it.noveltype)
 
                         if (episode != null) {
                             // データベースに保存
@@ -900,18 +893,16 @@ fun EpisodeListScreen(
                             .weight(1f)
                             .clickable(enabled = novel != null) {
                                 novel?.let { novelEntity ->
-                                    scope.launch {
-                                        val userId = fetchUserId(novelEntity.ncode, novelEntity.rating == 1)
-                                        if (userId != null) {
-                                            val url = if (novelEntity.rating == 1) {
-                                                "https://xmypage.syosetu.com/$userId/"
-                                            } else {
-                                                "https://mypage.syosetu.com/$userId/"
-                                            }
-                                            onAuthorClick(url)
+                                    val userId = novelEntity.userid
+                                    if (userId != null) {
+                                        val url = if (novelEntity.rating == 1) {
+                                            "https://xmypage.syosetu.com/$userId/"
                                         } else {
-                                            Toast.makeText(context, "作者ページを取得できませんでした", Toast.LENGTH_SHORT).show()
+                                            "https://mypage.syosetu.com/$userId/"
                                         }
+                                        onAuthorClick(url)
+                                    } else {
+                                        Toast.makeText(context, "すでになろうにいません", Toast.LENGTH_SHORT).show()
                                     }
                                 }
                             }
@@ -1125,49 +1116,6 @@ fun EpisodeItem(
     }
 }
 
-// API呼び出し関数: 作者のユーザーIDを取得
-private suspend fun fetchUserId(ncode: String, isR18: Boolean): String? {
-    if (ncode.isEmpty()) return null
-
-    return withContext(Dispatchers.IO) {
-        try {
-            val apiUrl = if (isR18) {
-                "https://api.syosetu.com/novel18api/api/?of=u&ncode=$ncode&gzip=5&json"
-            } else {
-                "https://api.syosetu.com/novelapi/api/?of=u&ncode=$ncode&gzip=5&json"
-            }
-
-            val connection = URL(apiUrl).openConnection() as HttpURLConnection
-            connection.requestMethod = "GET"
-            connection.connectTimeout = 10000
-            connection.readTimeout = 10000
-
-            if (connection.responseCode == HttpURLConnection.HTTP_OK) {
-                val inputStream = GZIPInputStream(connection.inputStream)
-                val reader = BufferedReader(InputStreamReader(inputStream))
-                val content = StringBuilder()
-                var line: String?
-                while (reader.readLine().also { line = it } != null) {
-                    content.append(line).append("\n")
-                }
-
-                val yaml = Yaml()
-                val yamlData = yaml.load<List<Map<String, Any>>>(content.toString())
-                if (yamlData.size >= 2) {
-                    val userId = yamlData[1]["user_id"]
-                    userId?.toString()
-                } else {
-                    null
-                }
-            } else {
-                null
-            }
-        } catch (e: Exception) {
-            Log.e("EpisodeListScreen", "作者ID取得エラー: ${e.message}", e)
-            null
-        }
-    }
-}
 
 // API呼び出し関数: APIから小説情報を取得
 private suspend fun fetchNovelInfo(ncode: String): Pair<Int, String> {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.shunlight_library.novel_reader.data.entity.LastReadNovelEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
+import com.shunlight_library.novel_reader.api.NovelApiUtils
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
@@ -36,6 +37,7 @@ enum class SortField(val displayName: String) {
     AUTHOR("作者"),
     TOTAL_EP("総話数"),
     UNREAD_COUNT("未読数"),
+    LENGTH("文字数"),
     LAST_UPDATE_DATE("更新日")
 }
 
@@ -59,7 +61,9 @@ data class FilterSettings(
     val hideRating5WithNoEpisodes: Boolean = false,
     val showCompleted: Boolean = true,
     val showOngoing: Boolean = true,
-    val showFavoritesOnly: Boolean = false
+    val showFavoritesOnly: Boolean = false,
+    val showLongNovels: Boolean = true,
+    val showShortNovels: Boolean = true
 )
 
 // 小説と既読情報を組み合わせたデータクラス
@@ -122,7 +126,9 @@ fun NovelListScreen(
                     hideRating5WithNoEpisodes = filterSettings.hideRating5WithNoEpisodes,
                     showCompleted = filterSettings.showCompleted,
                     showOngoing = filterSettings.showOngoing,
-                    showFavoritesOnly = filterSettings.showFavoritesOnly
+                    showFavoritesOnly = filterSettings.showFavoritesOnly,
+                    showLongNovels = filterSettings.showLongNovels,
+                    showShortNovels = filterSettings.showShortNovels
                 )
                 settingsStore.saveNovelListFilterSettings(settings)
             }
@@ -149,6 +155,14 @@ fun NovelListScreen(
 
             // お気に入りフィルターが有効な場合、お気に入りでない小説を除外
             if (filterSettings.showFavoritesOnly && !novel.is_favorite) {
+                return@filter false
+            }
+
+            // 長編・短編フィルター
+            if (!filterSettings.showLongNovels && novel.noveltype == 1) {
+                return@filter false
+            }
+            if (!filterSettings.showShortNovels && novel.noveltype == 2) {
                 return@filter false
             }
 
@@ -200,6 +214,11 @@ fun NovelListScreen(
             } else {
                 filtered.sortedByDescending { it.unreadCount }
             }
+            SortField.LENGTH -> if (sortDirection == SortDirection.ASCENDING) {
+                filtered.sortedBy { it.novel.length ?: 0 }
+            } else {
+                filtered.sortedByDescending { it.novel.length ?: 0 }
+            }
             SortField.LAST_UPDATE_DATE -> if (sortDirection == SortDirection.ASCENDING) {
                 filtered.sortedBy { it.novel.last_update_date }
             } else {
@@ -238,7 +257,9 @@ fun NovelListScreen(
             hideRating5WithNoEpisodes = savedFilterSettings.hideRating5WithNoEpisodes,
             showCompleted = savedFilterSettings.showCompleted,
             showOngoing = savedFilterSettings.showOngoing,
-            showFavoritesOnly = savedFilterSettings.showFavoritesOnly
+            showFavoritesOnly = savedFilterSettings.showFavoritesOnly,
+            showLongNovels = savedFilterSettings.showLongNovels,
+            showShortNovels = savedFilterSettings.showShortNovels
         )
     }
     
@@ -252,6 +273,23 @@ fun NovelListScreen(
     // 小説データの取得
     LaunchedEffect(key1 = Unit) {
         repository.allNovels.collect { novelsList ->
+            novelsList.forEach { novel ->
+                if (novel.userid == null || novel.noveltype == null || novel.length == null) {
+                    scope.launch {
+                        val info = NovelApiUtils.fetchNovelInfo(novel.ncode, novel.rating == 1)
+                        if (info != null) {
+                            repository.updateNovel(
+                                novel.copy(
+                                    userid = info.userid,
+                                    noveltype = info.noveltype,
+                                    length = info.length
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
             // 未読数を計算して小説情報を作成
             allNovels = novelsList.map { novel ->
                 val lastRead = lastReadMap[novel.ncode]
@@ -480,6 +518,54 @@ fun NovelListScreen(
                         )
                         Text(
                             text = "お気に入りのみ表示",
+                            modifier = Modifier.padding(start = 8.dp)
+                        )
+                    }
+
+                    // 長編を表示
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                filterSettings = filterSettings.copy(
+                                    showLongNovels = !filterSettings.showLongNovels
+                                )
+                            }
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = filterSettings.showLongNovels,
+                            onCheckedChange = { checked ->
+                                filterSettings = filterSettings.copy(showLongNovels = checked)
+                            }
+                        )
+                        Text(
+                            text = "長編を表示",
+                            modifier = Modifier.padding(start = 8.dp)
+                        )
+                    }
+
+                    // 短編を表示
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable {
+                                filterSettings = filterSettings.copy(
+                                    showShortNovels = !filterSettings.showShortNovels
+                                )
+                            }
+                            .padding(vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = filterSettings.showShortNovels,
+                            onCheckedChange = { checked ->
+                                filterSettings = filterSettings.copy(showShortNovels = checked)
+                            }
+                        )
+                        Text(
+                            text = "短編を表示",
                             modifier = Modifier.padding(start = 8.dp)
                         )
                     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -45,7 +45,9 @@ data class NovelListFilterSettings(
     val hideRating5WithNoEpisodes: Boolean = false,
     val showCompleted: Boolean = true,
     val showOngoing: Boolean = true,
-    val showFavoritesOnly: Boolean = false
+    val showFavoritesOnly: Boolean = false,
+    val showLongNovels: Boolean = true,
+    val showShortNovels: Boolean = true
 )
 
 // DataStoreのインスタンスをトップレベルで定義
@@ -104,6 +106,8 @@ class SettingsStore(private val context: Context) {
         val NOVEL_LIST_SHOW_COMPLETED = booleanPreferencesKey("novel_list_show_completed")
         val NOVEL_LIST_SHOW_ONGOING = booleanPreferencesKey("novel_list_show_ongoing")
         val NOVEL_LIST_SHOW_FAVORITES_ONLY = booleanPreferencesKey("novel_list_show_favorites_only")
+        val NOVEL_LIST_SHOW_LONG = booleanPreferencesKey("novel_list_show_long")
+        val NOVEL_LIST_SHOW_SHORT = booleanPreferencesKey("novel_list_show_short")
     }
 
     val defaultFontColor = "#000000" // 黒
@@ -143,6 +147,8 @@ class SettingsStore(private val context: Context) {
     val defaultNovelListShowCompleted = true
     val defaultNovelListShowOngoing = true
     val defaultNovelListShowFavoritesOnly = false
+    val defaultNovelListShowLong = true
+    val defaultNovelListShowShort = true
 
     val themeMode: Flow<String> = context.dataStore.data
         .catch { exception: Throwable ->
@@ -532,10 +538,12 @@ class SettingsStore(private val context: Context) {
             hideRating5WithNoEpisodes = preferences[NOVEL_LIST_HIDE_RATING5_NO_EPISODES] ?: defaultNovelListHideRating5NoEpisodes,
             showCompleted = preferences[NOVEL_LIST_SHOW_COMPLETED] ?: defaultNovelListShowCompleted,
             showOngoing = preferences[NOVEL_LIST_SHOW_ONGOING] ?: defaultNovelListShowOngoing,
-            showFavoritesOnly = preferences[NOVEL_LIST_SHOW_FAVORITES_ONLY] ?: defaultNovelListShowFavoritesOnly
+            showFavoritesOnly = preferences[NOVEL_LIST_SHOW_FAVORITES_ONLY] ?: defaultNovelListShowFavoritesOnly,
+            showLongNovels = preferences[NOVEL_LIST_SHOW_LONG] ?: defaultNovelListShowLong,
+            showShortNovels = preferences[NOVEL_LIST_SHOW_SHORT] ?: defaultNovelListShowShort
         )
     }
-    
+
     // 小説リストフィルター設定の保存
     suspend fun saveNovelListFilterSettings(settings: NovelListFilterSettings) {
         context.dataStore.edit { preferences ->
@@ -547,6 +555,8 @@ class SettingsStore(private val context: Context) {
             preferences[NOVEL_LIST_SHOW_COMPLETED] = settings.showCompleted
             preferences[NOVEL_LIST_SHOW_ONGOING] = settings.showOngoing
             preferences[NOVEL_LIST_SHOW_FAVORITES_ONLY] = settings.showFavoritesOnly
+            preferences[NOVEL_LIST_SHOW_LONG] = settings.showLongNovels
+            preferences[NOVEL_LIST_SHOW_SHORT] = settings.showShortNovels
         }
     }
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateCheckWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateCheckWorker.kt
@@ -58,37 +58,39 @@ class UpdateCheckWorker(
             for (novel in novels) {
                 try {
                     // APIから最新情報を取得
-                    val (newGeneralAllNo, newUpdatedAt) = NovelApiUtils.fetchNovelInfo(
+                    val info = NovelApiUtils.fetchNovelInfo(
                         novel.ncode,
                         novel.rating == 1
                     )
-
-                    // 更新がある場合
-                    if (newGeneralAllNo > novel.general_all_no) {
-                        // 小説情報を更新
+                    if (info != null) {
+                        // 常に最新情報を保存
                         val updatedNovel = novel.copy(
-                            general_all_no = newGeneralAllNo,
-                            updated_at = newUpdatedAt
+                            general_all_no = info.generalAllNo,
+                            updated_at = info.updatedAt,
+                            userid = novel.userid ?: info.userid,
+                            noveltype = novel.noveltype ?: info.noveltype,
+                            length = novel.length ?: info.length
                         )
                         repository.updateNovel(updatedNovel)
 
-                        // 更新キューに追加
-                        val updateQueue = UpdateQueueEntity(
-                            ncode = novel.ncode,
-                            total_ep = novel.total_ep,
-                            general_all_no = newGeneralAllNo,
-                            update_time = newUpdatedAt
-                        )
-                        repository.insertUpdateQueue(updateQueue)
+                        // 更新がある場合
+                        if (info.generalAllNo > novel.general_all_no) {
+                            val updateQueue = UpdateQueueEntity(
+                                ncode = novel.ncode,
+                                total_ep = novel.total_ep,
+                                general_all_no = info.generalAllNo,
+                                update_time = info.updatedAt
+                            )
+                            repository.insertUpdateQueue(updateQueue)
 
-                        // 新規か更新かをカウント
-                        if (novel.general_all_no == 0) {
-                            newCount++
-                        } else {
-                            updatedCount++
+                            if (novel.general_all_no == 0) {
+                                newCount++
+                            } else {
+                                updatedCount++
+                            }
+
+                            Log.d(TAG, "小説「${novel.title}」の更新を検出: ${info.generalAllNo} > ${novel.general_all_no}")
                         }
-
-                        Log.d(TAG, "小説「${novel.title}」の更新を検出: $newGeneralAllNo > ${novel.general_all_no}")
                     }
 
                     // APIへの負荷軽減のために少し待機

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -141,7 +141,7 @@ fun UpdateInfoScreen(
                                             novel.ncode,
                                             episodeNo,
                                             novel.rating == 1,
-                                            novel.general_all_no
+                                            novel.noveltype
                                         )
 
                                         if (episode != null) {
@@ -768,10 +768,10 @@ fun UpdateInfoScreen(
                                                 }
 
                                                 // APIから最新情報を取得
-                                                val (newGeneralAllNo, _) = NovelApiUtils.fetchNovelInfo(novel.ncode, novel.rating == 1)
+                                                val info = NovelApiUtils.fetchNovelInfo(novel.ncode, novel.rating == 1)
 
                                                 // 使用するgeneral_all_no値
-                                                val generalAllNoValue = if (newGeneralAllNo == -1) novel.general_all_no else newGeneralAllNo
+                                                val generalAllNoValue = info?.generalAllNo ?: novel.general_all_no
 
                                                 // エピソードのマップを作成
                                                 val episodeNumberMap = episodes.associate { episode ->

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -30,6 +30,14 @@ import java.util.zip.GZIPInputStream
 object NovelApiUtils {
     private const val TAG = "NovelApiUtils"
 
+    data class NovelApiInfo(
+        val generalAllNo: Int,
+        val updatedAt: String,
+        val userid: String?,
+        val noveltype: Int?,
+        val length: Int?
+    )
+
     /**
      * APIから小説情報を取得する
      * @param ncode 小説のNコード
@@ -37,16 +45,16 @@ object NovelApiUtils {
      * @return Pair(総エピソード数, 更新日時) 取得に失敗した場合は (-1, "")
      */
     // NovelApiUtils.kt の fetchNovelInfo 関数を修正
-    suspend fun fetchNovelInfo(ncode: String, isR18: Boolean = false, apiUrl: String? = null): Pair<Int, String> {
-        if (ncode.isEmpty()) return Pair(-1, "")
+    suspend fun fetchNovelInfo(ncode: String, isR18: Boolean = false, apiUrl: String? = null): NovelApiInfo? {
+        if (ncode.isEmpty()) return null
 
         return withContext(Dispatchers.IO) {
             try {
                 // API URLの構築
                 val actualApiUrl = apiUrl ?: if (isR18) {
-                    "https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5&json"
+                    "https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua-u-nt-l&ncode=$ncode&gzip=5&json"
                 } else {
-                    "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5&json"
+                    "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua-u-nt-l&ncode=$ncode&gzip=5&json"
                 }
 
                 val connection = URL(actualApiUrl).openConnection() as HttpURLConnection
@@ -71,6 +79,9 @@ object NovelApiUtils {
                     if (yamlData.size >= 2) {
                         val novelData = yamlData[1]
                         val newGeneralAllNo = novelData["general_all_no"] as Int
+                        val userid = novelData["userid"]?.toString()
+                        val noveltype = (novelData["noveltype"] as? Int)
+                        val length = (novelData["length"] as? Int)
 
                         // 更新日時の取得
                         val updatedAtObj = novelData["updated_at"]
@@ -80,16 +91,16 @@ object NovelApiUtils {
                             else -> DatabaseSyncUtils.getCurrentDateTimeString()
                         }
 
-                        Pair(newGeneralAllNo, newUpdatedAt)
+                        NovelApiInfo(newGeneralAllNo, newUpdatedAt, userid, noveltype, length)
                     } else {
-                        Pair(-1, "")
+                        null
                     }
                 } else {
-                    Pair(-1, "")
+                    null
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "API取得エラー: ${e.message}", e)
-                Pair(-1, "")
+                null
             }
         }
     }
@@ -105,9 +116,9 @@ object NovelApiUtils {
             try {
                 // API URLの構築
                 val apiUrl = if (isR18) {
-                    "https://api.syosetu.com/novel18api/api/?of=t-n-u-w-s-k-g-ga-e-l-ua&ncode=$ncode&gzip=5&json"
+                    "https://api.syosetu.com/novel18api/api/?of=t-n-u-w-s-k-g-ga-e-l-ua-nt&ncode=$ncode&gzip=5&json"
                 } else {
-                    "https://api.syosetu.com/novelapi/api/?of=t-n-u-w-s-k-g-ga-e-l-ua&ncode=$ncode&gzip=5&json"
+                    "https://api.syosetu.com/novelapi/api/?of=t-n-u-w-s-k-g-ga-e-l-ua-nt&ncode=$ncode&gzip=5&json"
                 }
 
                 val connection = URL(apiUrl).openConnection() as HttpURLConnection
@@ -136,6 +147,9 @@ object NovelApiUtils {
                         val author = novelData["writer"] as String
                         val synopsis = novelData["story"] as? String ?: ""
                         val generalAllNo = novelData["general_all_no"] as Int
+                        val userid = novelData["userid"]?.toString()
+                        val noveltype = (novelData["noveltype"] as? Int)
+                        val length = (novelData["length"] as? Int)
                         val keyword = novelData["keyword"] as? String ?: ""
 
                         // キーワードから最初のタグをメインタグ、残りをサブタグとして扱う
@@ -160,6 +174,9 @@ object NovelApiUtils {
                             last_update_date = currentDate,
                             total_ep = 0, // 初期値は0、後で更新処理で正確な値が設定される
                             general_all_no = generalAllNo,
+                            userid = userid,
+                            noveltype = noveltype,
+                            length = length,
                             updated_at = currentDate
                         )
                     } else {
@@ -188,7 +205,7 @@ object NovelApiUtils {
         ncode: String,
         episodeNo: Int,
         isR18: Boolean = false,
-        totalEpisodeCount: Int = -1
+        noveltype: Int? = null
     ): EpisodeEntity? {
         return withContext(Dispatchers.IO) {
             try {
@@ -197,7 +214,7 @@ object NovelApiUtils {
                 } else {
                     "https://ncode.syosetu.com"
                 }
-                val url = if (totalEpisodeCount == 1 && episodeNo == 1) {
+                val url = if (noveltype == 2) {
                     "$baseUrl/$ncode/"
                 } else {
                     "$baseUrl/$ncode/$episodeNo/"
@@ -310,12 +327,12 @@ object NovelApiUtils {
         ncode: String,
         episodeNo: Int,
         isR18: Boolean = false,
-        totalEpisodeCount: Int = -1,
+        noveltype: Int? = null,
         maxRetries: Int = 3
     ): EpisodeEntity? {
         for (attempt in 1..maxRetries) {
             try {
-                val episode = fetchEpisode(ncode, episodeNo, isR18, totalEpisodeCount)
+                val episode = fetchEpisode(ncode, episodeNo, isR18, noveltype)
                 if (episode != null) {
                     return episode
                 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
@@ -107,6 +107,19 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
 }
 
 /**
+ * v7→v8のマイグレーション: 作者ID、作品種別、文字数を追加
+ */
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL("ALTER TABLE novels_descs ADD COLUMN userid TEXT")
+        database.execSQL("ALTER TABLE novels_descs ADD COLUMN noveltype INTEGER")
+        database.execSQL("ALTER TABLE novels_descs ADD COLUMN length INTEGER")
+        database.execSQL("CREATE INDEX IF NOT EXISTS idx_novels_length ON novels_descs (length)")
+        database.execSQL("CREATE INDEX IF NOT EXISTS idx_novels_type ON novels_descs (noveltype)")
+    }
+}
+
+/**
  * アプリ全体で使用するRoomデータベース定義
  */
 @Database(
@@ -118,7 +131,7 @@ val MIGRATION_6_7 = object : Migration(6, 7) {
         URLEntity::class,
         ImageCacheEntity::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = false
 )
 abstract class NovelDatabase : RoomDatabase() {
@@ -149,7 +162,8 @@ abstract class NovelDatabase : RoomDatabase() {
                         MIGRATION_3_4,
                         MIGRATION_4_5,
                         MIGRATION_5_6,
-                        MIGRATION_6_7
+                        MIGRATION_6_7,
+                        MIGRATION_7_8
                     )
                     .build()
                 INSTANCE = instance

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/NovelDescEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/NovelDescEntity.kt
@@ -14,7 +14,9 @@ import androidx.room.Index
     indices = [
         Index(value = ["last_update_date"], name = "idx_novels_last_update"),
         Index(value = ["ncode", "rating", "total_ep", "general_all_no", "updated_at"], name = "idx_novels_update_check"),
-        Index(value = ["is_favorite"], name = "idx_novels_favorite")
+        Index(value = ["is_favorite"], name = "idx_novels_favorite"),
+        Index(value = ["length"], name = "idx_novels_length"),
+        Index(value = ["noveltype"], name = "idx_novels_type")
     ]
 )
 /**
@@ -44,6 +46,9 @@ data class NovelDescEntity(
     val last_update_date: String,
     val total_ep: Int,
     val general_all_no: Int,
+    val userid: String? = null,
+    val noveltype: Int? = null,
+    val length: Int? = null,
     val updated_at: String,
     val is_favorite: Boolean = false
 )

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncManager.kt
@@ -198,6 +198,9 @@ class DatabaseSyncManager(private val context: Context) {
             val columnLastUpdateDate = getColumnIndexOrDefault(cursor, "last_update_date")
             val columnTotalEp = getColumnIndexOrDefault(cursor, "total_ep")
             val columnGeneralAllNo = getColumnIndexOrDefault(cursor, "general_all_no")
+            val columnUserid = getColumnIndexOrDefault(cursor, "userid")
+            val columnNoveltype = getColumnIndexOrDefault(cursor, "noveltype")
+            val columnLength = getColumnIndexOrDefault(cursor, "length")
             val columnUpdatedAt = getColumnIndexOrDefault(cursor, "updated_at")
             val urlEntities = mutableListOf<URLEntity>() // URLEntityリスト追加
             val batchSize = 50
@@ -213,12 +216,13 @@ class DatabaseSyncManager(private val context: Context) {
                     main_tag = columnMainTag?.let { cursor.getString(it) } ?: "",
                     sub_tag = columnSubTag?.let { cursor.getString(it) } ?: "",
                     rating = columnRating?.let { cursor.getInt(it) } ?: 0,
-                    last_update_date = columnLastUpdateDate?.let { cursor.getString(it) } ?:
-                    getCurrentDateString(),
+                    last_update_date = columnLastUpdateDate?.let { cursor.getString(it) } ?: getCurrentDateString(),
                     total_ep = columnTotalEp?.let { cursor.getInt(it) } ?: 0,
                     general_all_no = columnGeneralAllNo?.let { cursor.getInt(it) } ?: 0,
-                    updated_at = columnUpdatedAt?.let { cursor.getString(it) } ?:
-                    getCurrentDateString()
+                    userid = columnUserid?.let { cursor.getString(it) }?.takeIf { it.isNotEmpty() },
+                    noveltype = columnNoveltype?.let { cursor.getInt(it) },
+                    length = columnLength?.let { cursor.getInt(it) },
+                    updated_at = columnUpdatedAt?.let { cursor.getString(it) } ?: getCurrentDateString()
                 )
 
                 novels.add(novel)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncUtils.kt
@@ -153,7 +153,11 @@ object DatabaseSyncUtils {
             ColumnInfo("last_update_date", "TEXT"),
             ColumnInfo("total_ep", "INTEGER"),
             ColumnInfo("general_all_no", "INTEGER"),
-            ColumnInfo("updated_at", "TEXT")
+            ColumnInfo("userid", "TEXT"),
+            ColumnInfo("noveltype", "INTEGER"),
+            ColumnInfo("length", "INTEGER"),
+            ColumnInfo("updated_at", "TEXT"),
+            ColumnInfo("is_favorite", "INTEGER")
         )
 
         // EpisodeEntityのテーブル定義

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/ImprovedDatabaseSyncManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/ImprovedDatabaseSyncManager.kt
@@ -316,6 +316,9 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
             val columnLastUpdateDate = getColumnIndexSafely(cursor, "last_update_date")
             val columnTotalEp = getColumnIndexSafely(cursor, "total_ep")
             val columnGeneralAllNo = getColumnIndexSafely(cursor, "general_all_no")
+            val columnUserid = getColumnIndexSafely(cursor, "userid")
+            val columnNoveltype = getColumnIndexSafely(cursor, "noveltype")
+            val columnLength = getColumnIndexSafely(cursor, "length")
             val columnUpdatedAt = getColumnIndexSafely(cursor, "updated_at")
 
             val batchSize = 50
@@ -323,6 +326,9 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
 
             // データの読み取りとバッチ処理
             while (cursor.moveToNext()) {
+                val userid = getStringSafely(cursor, columnUserid)
+                val noveltype = getIntSafely(cursor, columnNoveltype, -1)
+                val length = getIntSafely(cursor, columnLength, -1)
                 val novel = NovelDescEntity(
                     ncode = getStringSafely(cursor, columnNcode),
                     title = getStringSafely(cursor, columnTitle),
@@ -335,6 +341,9 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
                         DatabaseSyncUtils.getCurrentDateTimeString()),
                     total_ep = getIntSafely(cursor, columnTotalEp),
                     general_all_no = getIntSafely(cursor, columnGeneralAllNo),
+                    userid = if (userid.isEmpty()) null else userid,
+                    noveltype = if (columnNoveltype != null && !cursor.isNull(columnNoveltype)) noveltype else null,
+                    length = if (columnLength != null && !cursor.isNull(columnLength)) length else null,
                     updated_at = getStringSafely(cursor, columnUpdatedAt,
                         DatabaseSyncUtils.getCurrentDateTimeString())
                 )

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
@@ -249,32 +249,35 @@ class UpdateService : Service() {
                 val urlEntity = repository.getOrCreateURL(ncode, novel.rating == 1)
 
                 // Fetch latest info from API
-                val (newGeneralAllNo, newUpdatedAt) = NovelApiUtils.fetchNovelInfo(
+                val info = NovelApiUtils.fetchNovelInfo(
                     ncode = ncode,
                     isR18 = novel.rating == 1,
                     apiUrl = urlEntity.api_url
                 )
 
-                if (newGeneralAllNo == -1) {
+                if (info == null) {
                     updateComplete(false, "APIからデータが取得できませんでした")
                     return@launch
                 }
 
-                // Check if update is available
-                if (newGeneralAllNo > novel.general_all_no) {
-                    // Update novel info
-                    val updatedNovel = novel.copy(
-                        general_all_no = newGeneralAllNo,
-                        updated_at = newUpdatedAt
-                    )
-                    repository.updateNovel(updatedNovel)
+                // 常に最新情報を保存
+                val updatedNovel = novel.copy(
+                    general_all_no = info.generalAllNo,
+                    updated_at = info.updatedAt,
+                    userid = novel.userid ?: info.userid,
+                    noveltype = novel.noveltype ?: info.noveltype,
+                    length = novel.length ?: info.length
+                )
+                repository.updateNovel(updatedNovel)
 
+                // Check if update is available
+                if (info.generalAllNo > novel.general_all_no) {
                     // Add to update queue
                     val updateQueue = UpdateQueueEntity(
                         ncode = novel.ncode,
                         total_ep = novel.total_ep,
-                        general_all_no = newGeneralAllNo,
-                        update_time = newUpdatedAt
+                        general_all_no = info.generalAllNo,
+                        update_time = info.updatedAt
                     )
                     repository.insertUpdateQueue(updateQueue)
 
@@ -303,12 +306,18 @@ class UpdateService : Service() {
                 updateProgress(0.2f, "APIで最新情報を確認中...")
 
                 // Get latest info from API
-                val (newGeneralAllNo, newUpdatedAt) = NovelApiUtils.fetchNovelInfo(ncode, novel.rating == 1)
+                val info = NovelApiUtils.fetchNovelInfo(ncode, novel.rating == 1)
 
-                var generalAllNoValue = newGeneralAllNo
-                if (generalAllNoValue == -1) {
-                    generalAllNoValue = novel.general_all_no
-                }
+                var generalAllNoValue = info?.generalAllNo ?: novel.general_all_no
+                val newUpdatedAt = info?.updatedAt ?: novel.updated_at
+                val updatedNovel = novel.copy(
+                    general_all_no = generalAllNoValue,
+                    updated_at = newUpdatedAt,
+                    userid = novel.userid ?: info?.userid,
+                    noveltype = novel.noveltype ?: info?.noveltype,
+                    length = novel.length ?: info?.length
+                )
+                repository.updateNovel(updatedNovel)
 
                 // Start downloading episodes
                 updateProgress(0.3f, "エピソードを取得中... (0/$generalAllNoValue)")
@@ -333,7 +342,7 @@ class UpdateService : Service() {
                         novel.ncode,
                         episodeNo,
                         novel.rating == 1,
-                        generalAllNoValue
+                        novel.noveltype
                     )
 
                     if (episode != null) {
@@ -397,12 +406,17 @@ class UpdateService : Service() {
                 updateProgress(0.2f, "APIで最新情報を確認中...")
 
                 // Get latest info from API
-                val (newGeneralAllNo, _) = NovelApiUtils.fetchNovelInfo(ncode, novel.rating == 1)
+                val info = NovelApiUtils.fetchNovelInfo(ncode, novel.rating == 1)
 
-                var generalAllNoValue = newGeneralAllNo
-                if (generalAllNoValue == -1) {
-                    generalAllNoValue = novel.general_all_no
-                }
+                var generalAllNoValue = info?.generalAllNo ?: novel.general_all_no
+                val updatedNovel = novel.copy(
+                    general_all_no = generalAllNoValue,
+                    updated_at = info?.updatedAt ?: novel.updated_at,
+                    userid = novel.userid ?: info?.userid,
+                    noveltype = novel.noveltype ?: info?.noveltype,
+                    length = novel.length ?: info?.length
+                )
+                repository.updateNovel(updatedNovel)
 
                 // Find missing episodes
                 val episodeNumberMap = episodes.associate { episode ->
@@ -439,7 +453,7 @@ class UpdateService : Service() {
                         novel.ncode,
                         episodeNo,
                         novel.rating == 1,
-                        novel.general_all_no
+                        novel.noveltype
                     )
 
                     if (episode != null) {
@@ -541,7 +555,7 @@ class UpdateService : Service() {
                                 novel.ncode,
                                 episodeNo,
                                 novel.rating == 1,
-                                queueItem.general_all_no
+                                novel.noveltype
                             )
 
                             if (episode != null) {


### PR DESCRIPTION
## Summary
- store author ID, novel type, and length in novel database with migration
- expand API utilities and update routines to fetch new metadata and handle short stories
- enable length sorting and novel type filtering in novel list UI

## Testing
- `gradle build` *(fails: Plugin [id: 'com.android.application', version: '8.13.0'] was not found)*
- `gradle test` *(fails: Plugin [id: 'com.android.application', version: '8.13.0'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b20f379c832298b2269ece48cc7d