### PR TITLE
Persist novel list filters across navigation

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -114,25 +114,24 @@ fun NovelListScreen(
     var displayedNovels by remember { mutableStateOf<List<NovelWithReadInfo>>(emptyList()) }
     var lastReadMap by remember { mutableStateOf<Map<String, LastReadNovelEntity>>(emptyMap()) }
 
-    // 設定を保存する関数（手動呼び出し時のみ）
-    val saveCurrentSettings = remember {
-        {
-            scope.launch {
-                val settings = NovelListFilterSettings(
-                    sortField = sortField.name,
-                    sortDirection = sortDirection.name,
-                    minRating = filterSettings.minRating,
-                    maxRating = filterSettings.maxRating,
-                    hideRating5WithNoEpisodes = filterSettings.hideRating5WithNoEpisodes,
-                    showCompleted = filterSettings.showCompleted,
-                    showOngoing = filterSettings.showOngoing,
-                    showFavoritesOnly = filterSettings.showFavoritesOnly,
-                    showLongNovels = filterSettings.showLongNovels,
-                    showShortNovels = filterSettings.showShortNovels
-                )
-                settingsStore.saveNovelListFilterSettings(settings)
-            }
-        }
+    // 設定読み込み完了フラグ
+    var settingsLoaded by remember { mutableStateOf(false) }
+
+    // 設定を保存する関数
+    val saveCurrentSettings: suspend () -> Unit = {
+        val settings = NovelListFilterSettings(
+            sortField = sortField.name,
+            sortDirection = sortDirection.name,
+            minRating = filterSettings.minRating,
+            maxRating = filterSettings.maxRating,
+            hideRating5WithNoEpisodes = filterSettings.hideRating5WithNoEpisodes,
+            showCompleted = filterSettings.showCompleted,
+            showOngoing = filterSettings.showOngoing,
+            showFavoritesOnly = filterSettings.showFavoritesOnly,
+            showLongNovels = filterSettings.showLongNovels,
+            showShortNovels = filterSettings.showShortNovels
+        )
+        settingsStore.saveNovelListFilterSettings(settings)
     }
 
     // フィルターとソートを適用する関数
@@ -261,6 +260,8 @@ fun NovelListScreen(
             showLongNovels = savedFilterSettings.showLongNovels,
             showShortNovels = savedFilterSettings.showShortNovels
         )
+
+        settingsLoaded = true
     }
     
     // 最終既読情報の取得
@@ -309,6 +310,22 @@ fun NovelListScreen(
     // 検索、フィルター、ソートが変更されたとき
     LaunchedEffect(searchText, searchField, sortField, sortDirection, filterSettings, allNovels) {
         applyFiltersAndSort()
+    }
+
+    // 設定変更時の自動保存
+    LaunchedEffect(sortField, sortDirection, filterSettings, settingsLoaded) {
+        if (settingsLoaded) {
+            saveCurrentSettings()
+        }
+    }
+
+    // 画面離脱時にも設定を保存
+    DisposableEffect(Unit) {
+        onDispose {
+            if (settingsLoaded) {
+                scope.launch { saveCurrentSettings() }
+            }
+        }
     }
 
     // 並び替えダイアログ

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -312,3 +312,33 @@
 - Added ReleaseUtils utility and DataStore key for last notified release
 - Added version info button at bottom of main menu
 - Background check runs in AutoUpdateWorker and MainActivity
+
+## 2025/9/11
+### 1. NovelListScreen フィルター設定自動保存
+
+**問題**: フィルター変更後にダイアログ外をタップすると設定が保存されず、画面遷移するとリセットされる
+
+**解決策**:
+- 設定読み込み完了フラグを導入
+- `LaunchedEffect` で `sortField`・`sortDirection`・`filterSettings` の変更時に自動保存
+
+**変更ファイル**:
+- `NovelListScreen.kt`
+- `WORK_LOG.md`
+
+**効果**: 小説一覧ページのフィルター・ソート設定が画面遷移後も維持される
+
+## 2025/9/15
+### NovelListScreen フィルター設定再保存の改善
+
+**問題**: 設定を保存しても画面遷移時にリセットされることがあった
+
+**解決策**:
+- 設定保存処理をサスペンド関数化して確実に完了させる
+- 画面離脱時にも設定を保存する `DisposableEffect` を追加
+
+**変更ファイル**:
+- `NovelListScreen.kt`
+- `WORK_LOG.md`
+
+**効果**: フィルター設定が画面遷移後も確実に維持される


### PR DESCRIPTION
## Summary
- Ensure filter preferences save synchronously to DataStore
- Save filter settings again when leaving the list screen to prevent resets
- Update work log

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3445233c8832293b2e1cc587bd215