### PR TITLE
Add database export capability

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseExportManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseExportManager.kt
@@ -1,0 +1,87 @@
+/*
+ * eightman 2005-2025
+ * Furin-lab All Rights Reserved.
+ * Helper class for exporting the Room database to external storage.
+ */
+package com.shunlight_library.novel_reader.data.sync
+
+import android.content.Context
+import android.net.Uri
+import android.util.Log
+import com.shunlight_library.novel_reader.data.database.NovelDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.io.OutputStream
+
+/**
+ * 内部のRoomデータベースを外部へエクスポートするためのマネージャクラス。
+ */
+class DatabaseExportManager(private val context: Context) {
+
+    companion object {
+        private const val TAG = "DatabaseExportManager"
+        private const val DATABASE_NAME = "novel_database"
+    }
+
+    /**
+     * 書き出し処理の結果を保持するデータクラス。
+     */
+    data class ExportResult(
+        val success: Boolean,
+        val bytesCopied: Long = 0L,
+        val errorMessage: String? = null
+    )
+
+    /**
+     * 指定されたURIへデータベースファイルを書き出す。
+     *
+     * @param destinationUri 書き出し先のURI
+     * @return 書き出し処理の結果
+     */
+    suspend fun exportDatabase(destinationUri: Uri): ExportResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                // データベースのWALをチェックポイントして最新状態を反映
+                val supportDb = NovelDatabase.getDatabase(context).openHelper.writableDatabase
+                try {
+                    supportDb.query("PRAGMA wal_checkpoint(FULL)").use { }
+                } catch (e: Exception) {
+                    Log.w(TAG, "walチェックポイント中にエラー", e)
+                }
+
+                val databaseFile = context.getDatabasePath(DATABASE_NAME)
+                if (databaseFile == null || !databaseFile.exists()) {
+                    val message = "データベースファイルが見つかりません"
+                    Log.e(TAG, message)
+                    return@withContext ExportResult(success = false, errorMessage = message)
+                }
+
+                val bytes = copyFileToUri(databaseFile, destinationUri)
+                Log.d(TAG, "データベースを書き出しました: ${bytes} bytes")
+                ExportResult(success = true, bytesCopied = bytes)
+            } catch (e: Exception) {
+                Log.e(TAG, "データベース書き出し中にエラー", e)
+                ExportResult(success = false, errorMessage = e.localizedMessage)
+            }
+        }
+    }
+
+    private fun copyFileToUri(sourceFile: File, destinationUri: Uri): Long {
+        val contentResolver = context.contentResolver
+        var copiedBytes = 0L
+
+        val outputStream: OutputStream = contentResolver.openOutputStream(destinationUri, "w")
+            ?: throw IllegalStateException("出力ストリームを開けませんでした")
+
+        outputStream.use { outStream ->
+            FileInputStream(sourceFile).use { inputStream ->
+                copiedBytes = inputStream.copyTo(outStream)
+                outStream.flush()
+            }
+        }
+
+        return copiedBytes
+    }
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/DatabaseSyncActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/DatabaseSyncActivity.kt
@@ -15,6 +15,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -28,11 +29,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.lifecycleScope
+import com.shunlight_library.novel_reader.data.sync.DatabaseExportManager
 import com.shunlight_library.novel_reader.data.sync.ImprovedDatabaseSyncManager
 import com.shunlight_library.novel_reader.ui.theme.Novel_readerTheme
 import kotlinx.coroutines.launch
-import androidx.compose.foundation.background
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 class DatabaseSyncActivity : ComponentActivity() {
 
@@ -72,6 +75,8 @@ fun DatabaseSyncScreen(
     // 追加の状態変数
     var currentCount by remember { mutableStateOf(0) }
     var totalCount by remember { mutableStateOf(0) }
+    var isExporting by remember { mutableStateOf(false) }
+    var exportResult by remember { mutableStateOf<DatabaseExportManager.ExportResult?>(null) }
 
     // ログメッセージに関する状態変数を修正
     val maxLogMessages = 20 // 最大ログ表示数
@@ -103,6 +108,36 @@ fun DatabaseSyncScreen(
                     addLog("エラー: アクセス権限の取得に失敗しました")
                 }
             }
+        }
+    }
+
+    val exportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/octet-stream")
+    ) { uri ->
+        if (uri != null) {
+            val timestamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())
+            addLog("データベース書き出しを開始します ($timestamp)")
+            isExporting = true
+            exportResult = null
+            scope.launch {
+                val manager = DatabaseExportManager(context)
+                val result = manager.exportDatabase(uri)
+                exportResult = result
+                isExporting = false
+
+                if (result.success) {
+                    val sizeInKb = result.bytesCopied / 1024f
+                    val message = "書き出し完了: ${String.format(Locale.getDefault(), "%.1f", sizeInKb)}KB"
+                    addLog("完了: $message")
+                    Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+                } else {
+                    val errorMsg = result.errorMessage ?: "不明なエラー"
+                    addLog("エラー: 書き出しに失敗しました - $errorMsg")
+                    Toast.makeText(context, "書き出しに失敗しました", Toast.LENGTH_SHORT).show()
+                }
+            }
+        } else {
+            addLog("書き出しをキャンセルしました")
         }
     }
 
@@ -341,11 +376,71 @@ fun DatabaseSyncScreen(
 
                         Button(
                             onClick = { startSync() },
-                            enabled = selectedUri != null && !isSyncing,
+                            enabled = selectedUri != null && !isSyncing && !isExporting,
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             Text("同期を開始")
                         }
+                    }
+                }
+            }
+
+            // データベース書き出しセクション
+            Card(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    Text(
+                        text = "データベース書き出し",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+
+                    Text(
+                        text = "現在の内部データベースをバックアップとして書き出します。", 
+                        style = MaterialTheme.typography.bodySmall
+                    )
+
+                    if (isExporting) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                            Text("書き出し中...")
+                        }
+                    } else {
+                        exportResult?.let { result ->
+                            if (result.success) {
+                                Text(
+                                    text = "直近の書き出し: ${String.format(Locale.getDefault(), "%.1fKB", result.bytesCopied / 1024f)}",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            } else {
+                                Text(
+                                    text = "書き出しに失敗しました: ${result.errorMessage ?: "不明なエラー"}",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
+                    }
+
+                    Button(
+                        onClick = {
+                            val defaultName = "novel_database_backup_${SimpleDateFormat("yyyyMMdd_HHmmss", Locale.getDefault()).format(Date())}.db"
+                            exportLauncher.launch(defaultName)
+                        },
+                        enabled = !isSyncing && !isExporting,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("データベースを書き出す")
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add a DatabaseExportManager that checkpoints the Room database and copies it to a user-selected URI
- extend the database sync screen with a backup card, export progress indicator, and CreateDocument launcher

## Testing
- gradle test *(fails: missing Android SDK configuration in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ad28943c83229d3bd0f11fddce19