### PR TITLE
Persist list filters only when confirmed

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -81,7 +81,7 @@ fun NovelListScreen(
 ) {
     val repository = NovelReaderApplication.getRepository()
     val context = androidx.compose.ui.platform.LocalContext.current
-    val settingsStore = remember { SettingsStore(context) }
+    val settingsStore = remember(context) { SettingsStore(context.applicationContext) }
     val scope = rememberCoroutineScope()
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -136,6 +136,9 @@ fun NovelListScreen(
 
     // フィルターとソートを適用する関数
     fun applyFiltersAndSort() {
+        if (!settingsLoaded) {
+            return
+        }
         // フィルターの適用
         // フィルターの適用
         var filtered = allNovels.filter { novelWithInfo ->
@@ -262,17 +265,21 @@ fun NovelListScreen(
         )
 
         settingsLoaded = true
+        applyFiltersAndSort()
     }
-    
+
     // 最終既読情報の取得
-    LaunchedEffect(key1 = Unit) {
+    LaunchedEffect(settingsLoaded) {
+        if (!settingsLoaded) return@LaunchedEffect
         repository.allLastReadNovels.collect { lastReadList ->
             lastReadMap = lastReadList.associateBy { it.ncode }
+            applyFiltersAndSort()
         }
     }
 
     // 小説データの取得
-    LaunchedEffect(key1 = Unit) {
+    LaunchedEffect(settingsLoaded) {
+        if (!settingsLoaded) return@LaunchedEffect
         repository.allNovels.collect { novelsList ->
             novelsList.forEach { novel ->
                 if (novel.userid == null || novel.noveltype == null || novel.length == null) {
@@ -308,23 +315,9 @@ fun NovelListScreen(
     }
 
     // 検索、フィルター、ソートが変更されたとき
-    LaunchedEffect(searchText, searchField, sortField, sortDirection, filterSettings, allNovels) {
-        applyFiltersAndSort()
-    }
-
-    // 設定変更時の自動保存
-    LaunchedEffect(sortField, sortDirection, filterSettings, settingsLoaded) {
+    LaunchedEffect(searchText, searchField, sortField, sortDirection, filterSettings, allNovels, settingsLoaded) {
         if (settingsLoaded) {
-            saveCurrentSettings()
-        }
-    }
-
-    // 画面離脱時にも設定を保存
-    DisposableEffect(Unit) {
-        onDispose {
-            if (settingsLoaded) {
-                scope.launch { saveCurrentSettings() }
-            }
+            applyFiltersAndSort()
         }
     }
 
@@ -334,6 +327,9 @@ fun NovelListScreen(
             onDismissRequest = { showSortDialog = false },
             title = { Text("並び替え") },
             text = {
+                var tempSortField by remember(sortField) { mutableStateOf(sortField) }
+                var tempSortDirection by remember(sortDirection) { mutableStateOf(sortDirection) }
+
                 Column(modifier = Modifier.padding(8.dp)) {
                     // 並び替えフィールドの選択
                     Text("並び替え項目", style = MaterialTheme.typography.titleMedium)
@@ -343,13 +339,13 @@ fun NovelListScreen(
                         Row(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .clickable { sortField = field }
+                                .clickable { tempSortField = field }
                                 .padding(vertical = 8.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             RadioButton(
-                                selected = sortField == field,
-                                onClick = { sortField = field }
+                                selected = tempSortField == field,
+                                onClick = { tempSortField = field }
                             )
                             Text(
                                 text = field.displayName,
@@ -367,13 +363,13 @@ fun NovelListScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { sortDirection = SortDirection.ASCENDING }
+                            .clickable { tempSortDirection = SortDirection.ASCENDING }
                             .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         RadioButton(
-                            selected = sortDirection == SortDirection.ASCENDING,
-                            onClick = { sortDirection = SortDirection.ASCENDING }
+                            selected = tempSortDirection == SortDirection.ASCENDING,
+                            onClick = { tempSortDirection = SortDirection.ASCENDING }
                         )
                         Text(
                             text = "昇順 (A→Z, 小→大)",
@@ -384,13 +380,13 @@ fun NovelListScreen(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .clickable { sortDirection = SortDirection.DESCENDING }
+                            .clickable { tempSortDirection = SortDirection.DESCENDING }
                             .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         RadioButton(
-                            selected = sortDirection == SortDirection.DESCENDING,
-                            onClick = { sortDirection = SortDirection.DESCENDING }
+                            selected = tempSortDirection == SortDirection.DESCENDING,
+                            onClick = { tempSortDirection = SortDirection.DESCENDING }
                         )
                         Text(
                             text = "降順 (Z→A, 大→小)",
@@ -400,9 +396,13 @@ fun NovelListScreen(
                 }
             },
             confirmButton = {
-                Button(onClick = { 
+                Button(onClick = {
+                    sortField = tempSortField
+                    sortDirection = tempSortDirection
                     showSortDialog = false
-                    scope.launch { saveCurrentSettings() }
+                    if (settingsLoaded) {
+                        scope.launch { saveCurrentSettings() }
+                    }
                 }) {
                     Text("適用")
                 }
@@ -422,18 +422,20 @@ fun NovelListScreen(
             onDismissRequest = { showFilterDialog = false },
             title = { Text("フィルター設定") },
             text = {
+                var tempFilterSettings by remember(filterSettings) { mutableStateOf(filterSettings) }
+
                 Column(modifier = Modifier.padding(8.dp)) {
                     // 最低レーティング
-                    Text("最低レーティング: ${filterSettings.minRating}",
+                    Text("最低レーティング: ${tempFilterSettings.minRating}",
                         style = MaterialTheme.typography.bodyLarge)
                     Spacer(modifier = Modifier.height(8.dp))
 
                     Slider(
-                        value = filterSettings.minRating.toFloat(),
+                        value = tempFilterSettings.minRating.toFloat(),
                         onValueChange = {
                             // 最低値は最高値を超えないようにする
-                            val newMinRating = minOf(it.toInt(), filterSettings.maxRating)
-                            filterSettings = filterSettings.copy(minRating = newMinRating)
+                            val newMinRating = minOf(it.toInt(), tempFilterSettings.maxRating)
+                            tempFilterSettings = tempFilterSettings.copy(minRating = newMinRating)
                         },
                         valueRange = 0f..5f,
                         steps = 4,
@@ -455,16 +457,16 @@ fun NovelListScreen(
                     Spacer(modifier = Modifier.height(16.dp))
 
                     // 最高レーティング
-                    Text("最高レーティング: ${filterSettings.maxRating}",
+                    Text("最高レーティング: ${tempFilterSettings.maxRating}",
                         style = MaterialTheme.typography.bodyLarge)
                     Spacer(modifier = Modifier.height(8.dp))
 
                     Slider(
-                        value = filterSettings.maxRating.toFloat(),
+                        value = tempFilterSettings.maxRating.toFloat(),
                         onValueChange = {
                             // 最高値は最低値を下回らないようにする
-                            val newMaxRating = maxOf(it.toInt(), filterSettings.minRating)
-                            filterSettings = filterSettings.copy(maxRating = newMaxRating)
+                            val newMaxRating = maxOf(it.toInt(), tempFilterSettings.minRating)
+                            tempFilterSettings = tempFilterSettings.copy(maxRating = newMaxRating)
                         },
                         valueRange = 0f..5f,
                         steps = 4,
@@ -492,17 +494,17 @@ fun NovelListScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
-                                filterSettings = filterSettings.copy(
-                                    hideRating5WithNoEpisodes = !filterSettings.hideRating5WithNoEpisodes
+                                tempFilterSettings = tempFilterSettings.copy(
+                                    hideRating5WithNoEpisodes = !tempFilterSettings.hideRating5WithNoEpisodes
                                 )
                             }
                             .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Checkbox(
-                            checked = filterSettings.hideRating5WithNoEpisodes,
+                            checked = tempFilterSettings.hideRating5WithNoEpisodes,
                             onCheckedChange = { checked ->
-                                filterSettings = filterSettings.copy(
+                                tempFilterSettings = tempFilterSettings.copy(
                                     hideRating5WithNoEpisodes = checked
                                 )
                             }
@@ -518,17 +520,17 @@ fun NovelListScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
-                                filterSettings = filterSettings.copy(
-                                    showFavoritesOnly = !filterSettings.showFavoritesOnly
+                                tempFilterSettings = tempFilterSettings.copy(
+                                    showFavoritesOnly = !tempFilterSettings.showFavoritesOnly
                                 )
                             }
                             .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Checkbox(
-                            checked = filterSettings.showFavoritesOnly,
+                            checked = tempFilterSettings.showFavoritesOnly,
                             onCheckedChange = { checked ->
-                                filterSettings = filterSettings.copy(
+                                tempFilterSettings = tempFilterSettings.copy(
                                     showFavoritesOnly = checked
                                 )
                             }
@@ -544,17 +546,17 @@ fun NovelListScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
-                                filterSettings = filterSettings.copy(
-                                    showLongNovels = !filterSettings.showLongNovels
+                                tempFilterSettings = tempFilterSettings.copy(
+                                    showLongNovels = !tempFilterSettings.showLongNovels
                                 )
                             }
                             .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Checkbox(
-                            checked = filterSettings.showLongNovels,
+                            checked = tempFilterSettings.showLongNovels,
                             onCheckedChange = { checked ->
-                                filterSettings = filterSettings.copy(showLongNovels = checked)
+                                tempFilterSettings = tempFilterSettings.copy(showLongNovels = checked)
                             }
                         )
                         Text(
@@ -568,17 +570,17 @@ fun NovelListScreen(
                         modifier = Modifier
                             .fillMaxWidth()
                             .clickable {
-                                filterSettings = filterSettings.copy(
-                                    showShortNovels = !filterSettings.showShortNovels
+                                tempFilterSettings = tempFilterSettings.copy(
+                                    showShortNovels = !tempFilterSettings.showShortNovels
                                 )
                             }
                             .padding(vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Checkbox(
-                            checked = filterSettings.showShortNovels,
+                            checked = tempFilterSettings.showShortNovels,
                             onCheckedChange = { checked ->
-                                filterSettings = filterSettings.copy(showShortNovels = checked)
+                                tempFilterSettings = tempFilterSettings.copy(showShortNovels = checked)
                             }
                         )
                         Text(
@@ -589,9 +591,12 @@ fun NovelListScreen(
                 }
             },
             confirmButton = {
-                Button(onClick = { 
+                Button(onClick = {
+                    filterSettings = tempFilterSettings
                     showFilterDialog = false
-                    scope.launch { saveCurrentSettings() }
+                    if (settingsLoaded) {
+                        scope.launch { saveCurrentSettings() }
+                    }
                 }) {
                     Text("適用")
                 }
@@ -601,7 +606,9 @@ fun NovelListScreen(
                     // すべてのフィルターをリセット
                     filterSettings = FilterSettings()
                     showFilterDialog = false
-                    scope.launch { saveCurrentSettings() }
+                    if (settingsLoaded) {
+                        scope.launch { saveCurrentSettings() }
+                    }
                 }) {
                     Text("リセット")
                 }
@@ -664,6 +671,9 @@ fun NovelListScreen(
                                 SortDirection.DESCENDING
                             } else {
                                 SortDirection.ASCENDING
+                            }
+                            if (settingsLoaded) {
+                                scope.launch { saveCurrentSettings() }
                             }
                         }) {
                             Icon(


### PR DESCRIPTION
## Summary
- defer committing sort/filter selections until the user confirms so persistent settings are only updated intentionally
- use dialog-local state that is discarded on cancel, matching the Settings screen save semantics
- persist top-bar sort direction toggles after the stored preferences finish loading

## Testing
- ./gradlew test *(fails: Gradle wrapper is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d0acfffc04832281dfdcfd9205c18d