### PR TITLE
Add configurable image cache save location

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.documentfile.provider.DocumentFile
 import com.shunlight_library.novel_reader.data.sync.DatabaseSyncManager
 import com.shunlight_library.novel_reader.ui.DatabaseSyncActivity
 import com.shunlight_library.novel_reader.ui.components.DatabaseFileSelector
@@ -65,6 +66,7 @@ fun SettingsScreenUpdated(
     var swipeEnabled by remember { mutableStateOf(true) }
     var tapEnabled by remember { mutableStateOf(false) }
     var selfServerPath by remember { mutableStateOf("") }
+    var imageSaveLocation by remember { mutableStateOf("") }
 
     // 新しい状態変数を追加
     var fontColor by remember { mutableStateOf("#000000") }
@@ -103,6 +105,21 @@ fun SettingsScreenUpdated(
         MaterialTheme.colorScheme.background
     }
 
+    val imageSaveLocationLabel = remember(imageSaveLocation) {
+        if (imageSaveLocation.isBlank()) {
+            "未設定"
+        } else {
+            runCatching {
+                val uri = Uri.parse(imageSaveLocation)
+                DocumentFile.fromTreeUri(context, uri)?.name
+                    ?: uri.lastPathSegment
+                    ?: imageSaveLocation
+            }.getOrElse {
+                imageSaveLocation
+            }
+        }
+    }
+
     // フォントピッカーランチャーを定義
     val fontPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.StartActivityForResult()
@@ -136,6 +153,43 @@ fun SettingsScreenUpdated(
         }
     }
 
+    val imageDirectoryPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let {
+            val uriString = it.toString()
+            val contentResolver = context.contentResolver
+            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            try {
+                val alreadyPersisted = contentResolver.persistedUriPermissions.any { permission ->
+                    permission.uri == it
+                }
+                if (!alreadyPersisted) {
+                    contentResolver.takePersistableUriPermission(it, flags)
+                }
+
+                val previousUri = imageSaveLocation
+                imageSaveLocation = uriString
+                scope.launch {
+                    settingsStore.saveImageSaveLocation(uriString)
+                }
+
+                if (previousUri.isNotBlank() && previousUri != uriString) {
+                    runCatching {
+                        contentResolver.releasePersistableUriPermission(Uri.parse(previousUri), flags)
+                    }.onFailure { e ->
+                        Log.w("SettingsScreen", "前の保存先の権限解放に失敗: ${e.message}", e)
+                    }
+                }
+
+                Toast.makeText(context, "画像の保存先を設定しました", Toast.LENGTH_SHORT).show()
+            } catch (e: SecurityException) {
+                Log.e("SettingsScreen", "保存先ディレクトリの権限取得に失敗: ${e.message}", e)
+                Toast.makeText(context, "フォルダへのアクセス権限を取得できませんでした", Toast.LENGTH_LONG).show()
+            }
+        }
+    }
+
     // Load saved preferences when the screen is created
     LaunchedEffect(Unit) {
         try {
@@ -148,6 +202,7 @@ fun SettingsScreenUpdated(
             swipeEnabled = settingsStore.swipeEnabled.first()
             tapEnabled = settingsStore.tapEnabled.first()
             selfServerPath = settingsStore.selfServerPath.first()
+            imageSaveLocation = settingsStore.imageSaveLocation.first()
 
             // 表示関連の設定読み込み
             fontColor = settingsStore.fontColor.first()
@@ -461,6 +516,12 @@ fun SettingsScreenUpdated(
 
                                 // 自動更新設定を保存
                                 settingsStore.saveAutoUpdateSettings(autoUpdateEnabled, autoUpdateTime)
+
+                                if (imageSaveLocation.isNotBlank()) {
+                                    settingsStore.saveImageSaveLocation(imageSaveLocation)
+                                } else {
+                                    settingsStore.clearImageSaveLocation()
+                                }
 
                                 // 自動更新スケジュールを設定
                                 autoUpdateScheduler.scheduleAutoUpdate(autoUpdateEnabled, autoUpdateTime)
@@ -919,6 +980,83 @@ fun SettingsScreenUpdated(
                     )
                 }
             }
+            HorizontalDivider()
+
+            SettingSection(title = "画像保存先") {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    Text(
+                        text = "現在の保存先",
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Text(
+                        text = imageSaveLocationLabel,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                    if (imageSaveLocation.isNotBlank() && imageSaveLocationLabel != imageSaveLocation) {
+                        Text(
+                            text = imageSaveLocation,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Button(
+                        onClick = {
+                            val initialUri = imageSaveLocation
+                                .takeIf { it.isNotBlank() }
+                                ?.let { uriString -> runCatching { Uri.parse(uriString) }.getOrNull() }
+                            imageDirectoryPickerLauncher.launch(initialUri)
+                        },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Icon(Icons.Default.Folder, contentDescription = null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("フォルダを選択")
+                    }
+
+                    if (imageSaveLocation.isNotBlank()) {
+                        OutlinedButton(
+                            onClick = {
+                                val previousUri = imageSaveLocation
+                                val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+                                if (previousUri.isNotBlank()) {
+                                    runCatching {
+                                        val uri = Uri.parse(previousUri)
+                                        val hasPermission = context.contentResolver.persistedUriPermissions.any { it.uri == uri }
+                                        if (hasPermission) {
+                                            context.contentResolver.releasePersistableUriPermission(uri, flags)
+                                        }
+                                    }.onFailure { e ->
+                                        Log.w("SettingsScreen", "保存先の権限解放に失敗: ${e.message}", e)
+                                    }
+                                }
+
+                                imageSaveLocation = ""
+                                scope.launch {
+                                    settingsStore.clearImageSaveLocation()
+                                }
+                                Toast.makeText(context, "画像の保存先を未設定にしました", Toast.LENGTH_SHORT).show()
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 8.dp)
+                        ) {
+                            Icon(Icons.Default.Delete, contentDescription = null)
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text("保存先をクリア")
+                        }
+                    }
+                }
+            }
+
             HorizontalDivider()
 
             SettingSection(title = "自動更新設定") {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -63,6 +63,7 @@ class SettingsStore(private val context: Context) {
         val SELF_SERVER_ACCESS = booleanPreferencesKey("self_server_access")
         val TEXT_ORIENTATION = stringPreferencesKey("text_orientation")
         val SELF_SERVER_PATH_KEY = stringPreferencesKey("self_server_path")
+        val IMAGE_SAVE_LOCATION = stringPreferencesKey("image_save_location")
 
         // 追加する表示設定のキー
         val SHOW_TITLE = booleanPreferencesKey("show_title")
@@ -123,6 +124,7 @@ class SettingsStore(private val context: Context) {
     val defaultSelfServerAccess = false
     val defaultTextOrientation = "Horizontal"
     val defaultSelfServerPath = ""
+    val defaultImageSaveLocation = ""
 
     // デフォルト値
     val defaultShowTitle = true
@@ -225,6 +227,18 @@ class SettingsStore(private val context: Context) {
     val selfServerPath = context.dataStore.data.map { preferences: Preferences ->
         preferences[SELF_SERVER_PATH_KEY] ?: ""
     }
+
+    val imageSaveLocation: Flow<String> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[IMAGE_SAVE_LOCATION] ?: defaultImageSaveLocation
+        }
     val fontColor: Flow<String> = context.dataStore.data
         .catch { exception: Throwable ->
             if (exception is IOException) {
@@ -463,6 +477,23 @@ class SettingsStore(private val context: Context) {
         context.dataStore.edit { preferences: MutablePreferences ->
             preferences[SELF_SERVER_PATH_KEY] = path
         }
+    }
+
+    suspend fun saveImageSaveLocation(uri: String) {
+        context.dataStore.edit { preferences ->
+            preferences[IMAGE_SAVE_LOCATION] = uri
+        }
+    }
+
+    suspend fun clearImageSaveLocation() {
+        context.dataStore.edit { preferences ->
+            preferences.remove(IMAGE_SAVE_LOCATION)
+        }
+    }
+
+    suspend fun getImageSaveLocation(): String {
+        val preferences = context.dataStore.data.first()
+        return preferences[IMAGE_SAVE_LOCATION] ?: defaultImageSaveLocation
     }
     suspend fun saveFontColor(color: String) {
         context.dataStore.edit { preferences ->

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ImageCacheUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ImageCacheUtils.kt
@@ -1,12 +1,16 @@
 package com.shunlight_library.novel_reader.utils
 
+import android.net.Uri
 import android.util.Log
+import androidx.documentfile.provider.DocumentFile
 import com.shunlight_library.novel_reader.NovelReaderApplication
+import com.shunlight_library.novel_reader.SettingsStore
 import com.shunlight_library.novel_reader.data.entity.ImageCacheEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import java.io.IOException
 import java.net.HttpURLConnection
 import java.net.URL
 import java.security.MessageDigest
@@ -17,6 +21,14 @@ import java.security.MessageDigest
 object ImageCacheUtils {
     private const val TAG = "ImageCacheUtils"
 
+    private fun resolveLocalUri(localPath: String): String {
+        return when {
+            localPath.startsWith("content://") -> localPath
+            localPath.startsWith("file://") -> localPath
+            else -> "file://$localPath"
+        }
+    }
+
     /**
      * 指定されたURLの画像をダウンロードしてキャッシュし、ローカルURIを返す。
      * 既にハッシュが存在する場合は再利用する。
@@ -25,7 +37,7 @@ object ImageCacheUtils {
         val repository = NovelReaderApplication.getRepository()
         // URL一致で既存データを確認
         repository.getImageByUrl(url)?.let {
-            return "file://${it.local_path}"
+            return resolveLocalUri(it.local_path)
         }
 
         return withContext(Dispatchers.IO) {
@@ -44,7 +56,7 @@ object ImageCacheUtils {
 
                 // ハッシュで既存キャッシュを確認
                 repository.getImageByHash(hash)?.let {
-                    return@withContext "file://${it.local_path}"
+                    return@withContext resolveLocalUri(it.local_path)
                 }
 
                 val extension = when {
@@ -56,19 +68,61 @@ object ImageCacheUtils {
                 }
 
                 val context = NovelReaderApplication.getAppContext()
-                val file = File(context.filesDir, hash + extension)
-                FileOutputStream(file).use { it.write(bytes) }
+                val settingsStore = SettingsStore(context)
+
+                val storedPath = try {
+                    val directoryUriString = settingsStore.getImageSaveLocation()
+                    if (directoryUriString.isNotBlank()) {
+                        val directoryUri = Uri.parse(directoryUriString)
+                        val hasPersistedPermission = context.contentResolver.persistedUriPermissions.any { permission ->
+                            permission.uri == directoryUri && permission.isWritePermission
+                        }
+
+                        if (!hasPersistedPermission) {
+                            throw SecurityException("保存先ディレクトリへの書き込み権限がありません")
+                        }
+
+                        val documentDirectory = DocumentFile.fromTreeUri(context, directoryUri)
+                        if (documentDirectory != null && documentDirectory.isDirectory && documentDirectory.canWrite()) {
+                            val fileName = hash + extension
+                            val targetDocument = documentDirectory.findFile(fileName)
+                                ?: documentDirectory.createFile(mimeType, fileName)
+                            if (targetDocument != null) {
+                                context.contentResolver.openOutputStream(targetDocument.uri, "w")?.use { outputStream ->
+                                    outputStream.write(bytes)
+                                } ?: throw IOException("出力ストリームを開けませんでした")
+                                targetDocument.uri.toString()
+                            } else {
+                                throw IOException("保存先のファイルを作成できませんでした")
+                            }
+                        } else {
+                            throw IOException("保存先のディレクトリにアクセスできません")
+                        }
+                    } else {
+                        null
+                    }
+                } catch (e: SecurityException) {
+                    Log.w(TAG, "外部保存先への書き込み権限がありません: ${e.message}")
+                    null
+                } catch (e: Exception) {
+                    Log.w(TAG, "選択された保存先への書き込みに失敗: ${e.message}", e)
+                    null
+                } ?: run {
+                    val file = File(context.filesDir, hash + extension)
+                    FileOutputStream(file).use { it.write(bytes) }
+                    file.absolutePath
+                }
 
                 repository.insertImageCache(
                     ImageCacheEntity(
                         hash = hash,
                         original_url = url,
-                        local_path = file.absolutePath,
+                        local_path = storedPath,
                         mime_type = mimeType
                     )
                 )
 
-                "file://${file.absolutePath}"
+                resolveLocalUri(storedPath)
             } catch (e: Exception) {
                 Log.e(TAG, "画像ダウンロード失敗: ${e.message}", e)
                 null


### PR DESCRIPTION
## Summary
- add DataStore support for persisting the image cache save directory and retrieval helpers
- extend the settings screen with a folder picker, permission management, and controls to clear the chosen location
- update image caching to honor the user-selected directory via the Storage Access Framework while falling back to internal storage

## Testing
- gradle test *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fcff0b5c832295192c26517cd622