### PR TITLE
Add batch metadata update flow with user confirmation

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -47,7 +47,11 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import com.shunlight_library.novel_reader.metadata.MetadataUpdateManager
+import com.shunlight_library.novel_reader.metadata.MetadataUpdateResult
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class MainActivity : ComponentActivity() {
     private lateinit var navigationManager: NavigationManager
@@ -439,10 +443,20 @@ fun MainScreen(
     var novelInfo by remember { mutableStateOf<NovelDescEntity?>(null) }
     var updateInfoText by remember { mutableStateOf("新着0件・更新あり0件") }
     var showR18Dialog by remember { mutableStateOf(false) }
-    
+
     // 通知関連の状態
     var unreadNotificationCount by remember { mutableStateOf(0) }
     var showNotificationDialog by remember { mutableStateOf(false) }
+
+    // メタデータ補完ダイアログ用の状態
+    var showMetadataConfirm by remember { mutableStateOf(false) }
+    var showMetadataProgressDialog by remember { mutableStateOf(false) }
+    var isMetadataRunning by remember { mutableStateOf(false) }
+    var metadataProgress by remember { mutableStateOf(0f) }
+    var metadataStatusText by remember { mutableStateOf("処理を準備しています...") }
+    var metadataResult by remember { mutableStateOf<MetadataUpdateResult?>(null) }
+    var metadataProcessed by remember { mutableStateOf(0) }
+    var metadataTotal by remember { mutableStateOf(0) }
 
     var versionTapCount by remember { mutableStateOf(0) }
     var lastVersionTapTime by remember { mutableStateOf(0L) }
@@ -771,7 +785,7 @@ fun MainScreen(
                             onNavigate(Screen.Settings)
                         }
                     )
-                    
+
                     // 通知ボタン（バッジ付き）
                     Box {
                         MenuButton(
@@ -806,6 +820,24 @@ fun MainScreen(
                 }
             }
 
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    MenuButton(
+                        icon = "🗂",
+                        text = "メタデータ補完",
+                        onClick = {
+                            showMetadataConfirm = true
+                        }
+                    )
+                    Spacer(modifier = Modifier.width(160.dp))
+                }
+            }
+
             // アプリバージョン表示
             item {
                 Row(
@@ -824,6 +856,118 @@ fun MainScreen(
         }
     }
     
+    if (showMetadataConfirm) {
+        AlertDialog(
+            onDismissRequest = { showMetadataConfirm = false },
+            title = { Text("メタデータ補完の確認") },
+            text = { Text("不足しているメタデータをバッチ処理で取得しますか？") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showMetadataConfirm = false
+                    showMetadataProgressDialog = true
+                    isMetadataRunning = true
+                    metadataResult = null
+                    metadataProgress = 0f
+                    metadataProcessed = 0
+                    metadataTotal = 0
+                    metadataStatusText = "処理を準備しています..."
+                    scope.launch {
+                        val result = MetadataUpdateManager.updateMissingMetadata(repository) { processed, total ->
+                            withContext(Dispatchers.Main) {
+                                metadataTotal = total
+                                metadataProcessed = processed
+                                metadataProgress = if (total == 0) 1f else processed.toFloat() / total.toFloat()
+                                metadataStatusText = if (total == 0) {
+                                    "更新対象はありません。"
+                                } else {
+                                    "処理中... (${processed}/${total})"
+                                }
+                            }
+                        }
+
+                        withContext(Dispatchers.Main) {
+                            isMetadataRunning = false
+                            metadataResult = result
+                            metadataStatusText = when {
+                                result.hadError -> {
+                                    "処理中にエラーが発生しました。ログを確認してください。"
+                                }
+                                result.targets == 0 -> {
+                                    "更新対象の小説は見つかりませんでした。"
+                                }
+                                else -> {
+                                    "処理が完了しました。${result.targets}件中${result.updated}件のメタデータを更新しました。"
+                                }
+                            }
+                            metadataProgress = 1f
+                        }
+                    }
+                }) {
+                    Text("実行")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showMetadataConfirm = false }) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+
+    if (showMetadataProgressDialog) {
+        AlertDialog(
+            onDismissRequest = {
+                if (!isMetadataRunning) {
+                    showMetadataProgressDialog = false
+                }
+            },
+            title = {
+                Text(if (isMetadataRunning) "メタデータ補完を実行中" else "メタデータ補完の結果")
+            },
+            text = {
+                Column {
+                    if (isMetadataRunning) {
+                        LinearProgressIndicator(
+                            progress = metadataProgress.coerceIn(0f, 1f),
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                        Spacer(modifier = Modifier.height(12.dp))
+                        Text(metadataStatusText)
+                        if (metadataTotal > 0) {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text("${metadataProcessed}/${metadataTotal}")
+                        }
+                    } else {
+                        Text(metadataStatusText)
+                        metadataResult?.let { result ->
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Text("対象作品: ${result.targets}件")
+                            Text("更新された作品: ${result.updated}件")
+                            if (result.hadError) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    "処理中に問題が発生しました。詳細はログを確認してください。",
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {
+                if (isMetadataRunning) {
+                    TextButton(onClick = { }, enabled = false) {
+                        Text("処理中")
+                    }
+                } else {
+                    TextButton(onClick = { showMetadataProgressDialog = false }) {
+                        Text("閉じる")
+                    }
+                }
+            }
+        )
+    }
+
     // 通知ダイアログ
     if (showNotificationDialog && notificationStore != null) {
         NotificationDialog(

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
@@ -12,7 +12,6 @@ import androidx.work.*
 import com.shunlight_library.novel_reader.data.database.NovelDatabase
 import com.shunlight_library.novel_reader.data.repository.NovelRepository
 import com.shunlight_library.novel_reader.worker.UpdateCheckWorker
-import com.shunlight_library.novel_reader.api.NovelApiUtils
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.first
 import java.util.Calendar
@@ -61,8 +60,6 @@ class NovelReaderApplication : Application() {
         // アプリ起動時に自動更新スケジュールを設定
         setupUpdateSchedule()
 
-        // 既存DBの小説情報をチェックし不足データを補完
-        checkNovelMetadata()
     }
 
     /**
@@ -141,28 +138,4 @@ class NovelReaderApplication : Application() {
         }
     }
 
-    /**
-     * データベース内の小説を走査し、作者IDなどの不足データを補完する
-     * すでに削除されているなどAPIから情報が取得できない場合は警告を出さない
-     */
-    private fun checkNovelMetadata() {
-        CoroutineScope(Dispatchers.IO).launch {
-            val novels = repository.allNovels.first()
-            novels.forEach { novel ->
-                if (novel.userid == null || novel.noveltype == null || novel.length == null) {
-                    val info = NovelApiUtils.fetchNovelInfo(novel.ncode, novel.rating == 1)
-                    if (info != null) {
-                        Log.w("NovelReaderApp", "小説 ${novel.ncode} のメタデータが不足していたため取得しました")
-                        repository.updateNovel(
-                            novel.copy(
-                                userid = info.userid,
-                                noveltype = info.noveltype,
-                                length = info.length
-                            )
-                        )
-                    }
-                }
-            }
-        }
-    }
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/metadata/MetadataUpdateManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/metadata/MetadataUpdateManager.kt
@@ -1,0 +1,87 @@
+package com.shunlight_library.novel_reader.metadata
+
+import android.util.Log
+import com.shunlight_library.novel_reader.api.NovelApiUtils
+import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
+import com.shunlight_library.novel_reader.data.repository.NovelRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+data class MetadataUpdateResult(
+    val targets: Int,
+    val updated: Int,
+    val hadError: Boolean = false
+)
+
+object MetadataUpdateManager {
+    private const val TAG = "NovelReaderApp"
+
+    suspend fun updateMissingMetadata(
+        repository: NovelRepository,
+        onProgress: suspend (processed: Int, total: Int) -> Unit = { _, _ -> }
+    ): MetadataUpdateResult {
+        return withContext(Dispatchers.IO) {
+            try {
+                val novels = repository.allNovels.first()
+                val targets = novels.filter { it.needsMetadataSupplement() }
+
+                onProgress(0, targets.size)
+
+                var updatedCount = 0
+
+                targets.forEachIndexed { index, novel ->
+                    processNovel(repository, novel)?.let { afterImproved ->
+                        if (afterImproved) {
+                            updatedCount++
+                        }
+                    }
+
+                    onProgress(index + 1, targets.size)
+                }
+
+                MetadataUpdateResult(targets.size, updatedCount)
+            } catch (e: Exception) {
+                Log.e(TAG, "メタデータのバッチ更新中にエラーが発生しました: ${e.message}", e)
+                MetadataUpdateResult(0, 0, hadError = true)
+            }
+        }
+    }
+
+    private suspend fun processNovel(
+        repository: NovelRepository,
+        novel: NovelDescEntity
+    ): Boolean? {
+        val beforeCount = novel.metadataCount()
+        val info = NovelApiUtils.fetchNovelInfo(novel.ncode, novel.rating == 1)
+        if (info != null) {
+            val updatedNovel = novel.copy(
+                userid = novel.userid ?: info.userid,
+                noveltype = novel.noveltype ?: info.noveltype,
+                length = novel.length ?: info.length
+            )
+            val afterCount = updatedNovel.metadataCount()
+
+            Log.w(
+                TAG,
+                "小説 ${novel.ncode} のメタデータが不足していたため取得しました (再取得前: ${beforeCount}項目, 再取得後: ${afterCount}項目)"
+            )
+
+            if (afterCount > beforeCount || updatedNovel != novel) {
+                repository.updateNovel(updatedNovel)
+            }
+
+            return afterCount > beforeCount
+        }
+
+        return null
+    }
+
+    private fun NovelDescEntity.needsMetadataSupplement(): Boolean {
+        return userid == null || noveltype == null || length == null
+    }
+
+    private fun NovelDescEntity.metadataCount(): Int {
+        return listOf(userid, noveltype, length).count { it != null }
+    }
+}


### PR DESCRIPTION
## Summary
- add a MetadataUpdateManager to batch supplement missing novel metadata and log pre/post counts
- update MainScreen UI to ask the user before running metadata supplementation and show a progress dialog while it runs
- remove the automatic metadata check from the application startup in favor of the new user-triggered batch flow

## Testing
- `./gradlew test` *(fails: ./gradlew script is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fd9bcc2883228dbdf9daf017670d