### PR TITLE
Fix dialog temp state scoping for sorting/filtering

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -328,13 +328,13 @@ fun NovelListScreen(
 
     // 並び替えダイアログ
     if (showSortDialog) {
+        var tempSortField by remember(showSortDialog, sortField) { mutableStateOf(sortField) }
+        var tempSortDirection by remember(showSortDialog, sortDirection) { mutableStateOf(sortDirection) }
+
         AlertDialog(
             onDismissRequest = { showSortDialog = false },
             title = { Text("並び替え") },
             text = {
-                var tempSortField by remember(sortField) { mutableStateOf(sortField) }
-                var tempSortDirection by remember(sortDirection) { mutableStateOf(sortDirection) }
-
                 Column(modifier = Modifier.padding(8.dp)) {
                     // 並び替えフィールドの選択
                     Text("並び替え項目", style = MaterialTheme.typography.titleMedium)
@@ -423,12 +423,12 @@ fun NovelListScreen(
     // フィルターダイアログ
     // フィルターダイアログ
     if (showFilterDialog) {
+        var tempFilterSettings by remember(showFilterDialog, filterSettings) { mutableStateOf(filterSettings) }
+
         AlertDialog(
             onDismissRequest = { showFilterDialog = false },
             title = { Text("フィルター設定") },
             text = {
-                var tempFilterSettings by remember(filterSettings) { mutableStateOf(filterSettings) }
-
                 Column(modifier = Modifier.padding(8.dp)) {
                     // 最低レーティング
                     Text("最低レーティング: ${tempFilterSettings.minRating}",


### PR DESCRIPTION
## Summary
- hoist the temporary sort field and direction state so the dialog buttons can access them
- hoist the temporary filter settings state so the dialog buttons can access it without compile errors

## Testing
- ./gradlew build *(fails: ./gradlew: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d27fb639bc8322b9302ee142228e4d