### PR TITLE
Add delete option to episode list menu

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -92,6 +92,10 @@ fun EpisodeListScreen(
     var missingEpisodeCount by remember { mutableStateOf(0) }
     var redownloadTargets by remember { mutableStateOf<List<Int>>(emptyList()) }
 
+    var isMenuExpanded by remember { mutableStateOf(false) }
+    var showDeleteNovelDialog by remember { mutableStateOf(false) }
+    var isDeletingNovel by remember { mutableStateOf(false) }
+
     // データの取得
     LaunchedEffect(ncode) {
         // 小説情報の取得
@@ -752,6 +756,63 @@ fun EpisodeListScreen(
         )
     }
 
+    if (showDeleteNovelDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteNovelDialog = false },
+            title = { Text("小説を削除") },
+            text = {
+                Text("この小説と関連するデータを削除しますか？")
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showDeleteNovelDialog = false
+                        val currentNovel = novel
+                        if (currentNovel == null) {
+                            Toast.makeText(context, "小説情報が読み込まれていません", Toast.LENGTH_SHORT).show()
+                        } else {
+                            isDeletingNovel = true
+                            scope.launch {
+                                try {
+                                    repository.deleteNovelWithRelations(currentNovel)
+                                    Toast.makeText(context, "小説を削除しました", Toast.LENGTH_SHORT).show()
+                                    onBack()
+                                } catch (e: Exception) {
+                                    Log.e("EpisodeListScreen", "小説削除エラー: ${e.message}", e)
+                                    Toast.makeText(context, "小説の削除に失敗しました: ${e.message}", Toast.LENGTH_SHORT).show()
+                                } finally {
+                                    isDeletingNovel = false
+                                }
+                            }
+                        }
+                    }
+                ) {
+                    Text("削除")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteNovelDialog = false }) {
+                    Text("キャンセル")
+                }
+            }
+        )
+    }
+
+    if (isDeletingNovel) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("処理中") },
+            text = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                    Spacer(modifier = Modifier.width(16.dp))
+                    Text("小説を削除しています...")
+                }
+            },
+            confirmButton = {}
+        )
+    }
+
     // 画面の構成
     Scaffold(
         topBar = {
@@ -796,6 +857,28 @@ fun EpisodeListScreen(
                             contentDescription = if (novel?.is_favorite == true) "お気に入りから削除" else "お気に入りに追加",
                             tint = if (novel?.is_favorite == true) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                         )
+                    }
+                    Box {
+                        IconButton(
+                            onClick = { isMenuExpanded = true },
+                            enabled = novel != null
+                        ) {
+                            Icon(Icons.Default.MoreVert, contentDescription = "その他の操作")
+                        }
+                        DropdownMenu(
+                            expanded = isMenuExpanded,
+                            onDismissRequest = { isMenuExpanded = false }
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("小説を削除") },
+                                leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },
+                                onClick = {
+                                    isMenuExpanded = false
+                                    showDeleteNovelDialog = true
+                                },
+                                enabled = !isDeletingNovel
+                            )
+                        }
                     }
                 }
             )

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -122,6 +122,18 @@ class NovelRepository(
     suspend fun deleteUpdateQueueByNcode(ncode: String) {
         updateQueueDao.deleteUpdateQueueByNcode(ncode)
     }
+
+    suspend fun deleteNovelWithRelations(novel: NovelDescEntity) {
+        withContext(Dispatchers.IO) {
+            episodeDao.deleteEpisodesByNcode(novel.ncode)
+            lastReadNovelDao.getLastReadByNcode(novel.ncode)?.let {
+                lastReadNovelDao.deleteLastRead(it)
+            }
+            updateQueueDao.deleteUpdateQueueByNcode(novel.ncode)
+            urlEntityDao.deleteURLByNcode(novel.ncode)
+            novelDescDao.deleteNovel(novel)
+        }
+    }
     // NovelRepository.kt に追加
 
     // 更新チェック対象の小説を取得するメソッド


### PR DESCRIPTION
## Summary
- add an overflow menu to the episode list top app bar with a novel deletion option
- implement repository support to remove a novel and all related records
- show confirmation and progress dialogs while deleting a novel

## Testing
- not run (missing ./gradlew wrapper)


------
https://chatgpt.com/codex/tasks/task_e_68dde66171dc8322af4f19f30ce537db