### PR TITLE
Ensure update cancellations finish before starting new work

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -206,46 +207,115 @@ fun EpisodeListScreen(
 
     // 「再取得」実行関数
     fun performRedownload() {
+        val targetNovel = novel
+        if (targetNovel == null) {
+            Toast.makeText(context, "小説情報が読み込まれていません", Toast.LENGTH_SHORT).show()
+            return
+        }
+
         isUpdating = true
         updateProgress = 0f
         updateMessage = "エピソードを削除中..."
 
         scope.launch {
+            val ncode = targetNovel.ncode
             try {
-                // エピソードを削除
-                withContext(Dispatchers.IO) {
-                    novel?.let {
-                        repository.deleteEpisodesByNcode(it.ncode)
+                updateMessage = "他の更新処理の終了を待機しています..."
+                val cancelled = NovelUpdateCoordinator.cancelAndWait(ncode)
+                if (!cancelled) {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "他の更新処理を停止できませんでした"
+                        Toast.makeText(
+                            context,
+                            "進行中の更新を停止できませんでした。時間を置いて再度お試しください。",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        delay(1500)
+                        isUpdating = false
+                        showUpdateDialog = false
+                    }
+                    return@launch
+                }
+
+                val session = NovelUpdateCoordinator.awaitUpdateSlot(ncode)
+                if (session == null) {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "他の更新処理を待機中です"
+                        Toast.makeText(context, "他の更新処理が進行中です。時間を置いて再度お試しください。", Toast.LENGTH_SHORT).show()
+                        delay(1500)
+                        isUpdating = false
+                        showUpdateDialog = false
+                    }
+                    return@launch
+                }
+
+                suspend fun handleCancellation() {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "処理が中断されました"
+                        Toast.makeText(context, "更新処理が中断されました", Toast.LENGTH_SHORT).show()
+                        delay(1500)
+                        isUpdating = false
+                        showUpdateDialog = false
                     }
                 }
 
-                updateProgress = 0.3f
-                updateMessage = "APIで最新情報を確認中..."
+                try {
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
 
-                val (newGeneralAllNo, newUpdatedAt) = fetchNovelInfo(novel?.ncode ?: "")
+                    // エピソードを削除
+                    withContext(Dispatchers.IO) {
+                        repository.deleteEpisodesByNcode(ncode)
+                    }
 
-                var generalAllNoValue = newGeneralAllNo
-                if (generalAllNoValue == -1) {
-                    // APIから取得失敗時は既存の値を使用
-                    generalAllNoValue = novel?.general_all_no ?: 0
-                }
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
 
-                // 小説情報を更新
-                novel?.let { currentNovel ->
-                    val updatedNovel = currentNovel.copy(
+                    updateProgress = 0.3f
+                    updateMessage = "APIで最新情報を確認中..."
+
+                    val (newGeneralAllNo, newUpdatedAt) = fetchNovelInfo(ncode)
+
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
+
+                    var generalAllNoValue = newGeneralAllNo
+                    if (generalAllNoValue == -1) {
+                        // APIから取得失敗時は既存の値を使用
+                        generalAllNoValue = targetNovel.general_all_no
+                    }
+
+                    // 小説情報を更新
+                    val updatedNovel = targetNovel.copy(
                         general_all_no = generalAllNoValue,
                         total_ep = 0, // エピソードを削除したので0に
                         updated_at = newUpdatedAt
                     )
                     repository.updateNovel(updatedNovel)
-                }
 
-                // 確認ダイアログを表示するためにUIスレッドに戻る
-                withContext(Dispatchers.Main) {
-                    tempGeneralAllNo = generalAllNoValue
-                    isUpdating = false
-                    showUpdateDialog = false
-                    showDownloadConfirmDialog = true
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
+
+                    // 確認ダイアログを表示するためにUIスレッドに戻る
+                    withContext(Dispatchers.Main) {
+                        tempGeneralAllNo = generalAllNoValue
+                        isUpdating = false
+                        showUpdateDialog = false
+                        showDownloadConfirmDialog = true
+                    }
+                } finally {
+                    NovelUpdateCoordinator.finishUpdate(session)
                 }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
@@ -262,25 +332,81 @@ fun EpisodeListScreen(
 
     // エピソードをダウンロードする関数
     fun performDownloadEpisodes(generalAllNo: Int) {
+        val targetNovel = novel
+        if (targetNovel == null) {
+            Toast.makeText(context, "小説情報が読み込まれていません", Toast.LENGTH_SHORT).show()
+            return
+        }
+
         isUpdating = true
         updateProgress = 0.3f
         updateMessage = "エピソードを取得中... (0/$generalAllNo)"
 
         scope.launch {
+            val ncode = targetNovel.ncode
             try {
-                // 更新日時
-                val currentDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
+                updateMessage = "他の更新処理の終了を待機しています..."
+                val cancelled = NovelUpdateCoordinator.cancelAndWait(ncode)
+                if (!cancelled) {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "他の更新処理を停止できませんでした"
+                        Toast.makeText(
+                            context,
+                            "進行中の更新を停止できませんでした。時間を置いて再度お試しください。",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        delay(1500)
+                        isUpdating = false
+                    }
+                    return@launch
+                }
 
-                var successCount = 0
-                var failCount = 0
+                val session = NovelUpdateCoordinator.awaitUpdateSlot(ncode)
+                if (session == null) {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "他の更新処理を待機中です"
+                        Toast.makeText(context, "他の更新処理が進行中です。時間を置いて再度お試しください。", Toast.LENGTH_SHORT).show()
+                        delay(1500)
+                        isUpdating = false
+                    }
+                    return@launch
+                }
 
-                // エピソード番号のリスト
-                val episodeNumbers = (1..generalAllNo).toList()
+                suspend fun handleCancellation() {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "処理が中断されました"
+                        Toast.makeText(context, "更新処理が中断されました", Toast.LENGTH_SHORT).show()
+                        delay(1500)
+                        isUpdating = false
+                    }
+                }
 
-                // スクレイピングの実行
-                for ((index, episodeNo) in episodeNumbers.withIndex()) {
-                    novel?.let {
-                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, it.noveltype)
+                try {
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
+
+                    // 更新日時
+                    val currentDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
+
+                    var successCount = 0
+                    var failCount = 0
+
+                    // エピソード番号のリスト
+                    val episodeNumbers = (1..generalAllNo).toList()
+
+                    // スクレイピングの実行
+                    for ((index, episodeNo) in episodeNumbers.withIndex()) {
+                        if (session.isCancelled()) {
+                            handleCancellation()
+                            return@launch
+                        }
+
+                        val episode = fetchEpisode(ncode, episodeNo, targetNovel.rating == 1, targetNovel.noveltype)
 
                         if (episode != null) {
                             // データベースに保存
@@ -291,33 +417,39 @@ fun EpisodeListScreen(
                         } else {
                             failCount++
                         }
+
+                        // サーバーに負荷をかけないように少し待機
+                        delay(50)
+
+                        // 進捗を更新
+                        val progress = (index + 1).toFloat() / generalAllNo
+                        updateProgress = 0.3f + (0.7f * progress)
+                        updateMessage = "エピソードを取得中... (${index + 1}/$generalAllNo)"
                     }
 
-                    // サーバーに負荷をかけないように少し待機
-                    delay(50) // 1秒待機
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
 
-                    // 進捗を更新
-                    val progress = (index + 1).toFloat() / generalAllNo
-                    updateProgress = 0.3f + (0.7f * progress)
-                    updateMessage = "エピソードを取得中... (${index + 1}/$generalAllNo)"
-                }
-
-                // 小説のtotal_epを更新
-                novel?.let {
-                    val updatedNovel = it.copy(
+                    // 小説のtotal_epを更新
+                    val updatedNovel = targetNovel.copy(
                         total_ep = successCount,
-                        general_all_no = generalAllNo
+                        general_all_no = generalAllNo,
+                        updated_at = currentDate
                     )
                     repository.updateNovel(updatedNovel)
-                }
 
-                // 処理結果の通知
-                withContext(Dispatchers.Main) {
-                    updateProgress = 1f
-                    updateMessage = "完了: 成功${successCount}件、失敗${failCount}件"
-                    Toast.makeText(context, "完了: 成功${successCount}件、失敗${failCount}件", Toast.LENGTH_SHORT).show()
-                    delay(2000)
-                    isUpdating = false
+                    // 処理結果の通知
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "完了: 成功${successCount}件、失敗${failCount}件"
+                        Toast.makeText(context, "完了: 成功${successCount}件、失敗${failCount}件", Toast.LENGTH_SHORT).show()
+                        delay(2000)
+                        isUpdating = false
+                    }
+                } finally {
+                    NovelUpdateCoordinator.finishUpdate(session)
                 }
             } catch (e: Exception) {
                 withContext(Dispatchers.Main) {
@@ -447,19 +579,74 @@ fun EpisodeListScreen(
 
     // エラー修正の実行関数
     fun executeErrorFix() {
+        val targetNovel = novel
+        if (targetNovel == null) {
+            Toast.makeText(context, "小説情報が読み込まれていません", Toast.LENGTH_SHORT).show()
+            return
+        }
+
         isUpdating = true
         updateProgress = 0.3f
         updateMessage = "エラーまたは欠番のあるエピソードを再取得中... (0/${redownloadTargets.size})"
 
         scope.launch {
             try {
-                var successCount = 0
-                var failCount = 0
+                updateMessage = "他の更新処理の終了を待機しています..."
+                val cancelled = NovelUpdateCoordinator.cancelAndWait(targetNovel.ncode)
+                if (!cancelled) {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "他の更新処理を停止できませんでした"
+                        Toast.makeText(
+                            context,
+                            "進行中の更新を停止できませんでした。時間を置いて再度お試しください。",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        delay(1500)
+                        isUpdating = false
+                    }
+                    return@launch
+                }
 
-                // スクレイピングの実行
-                novel?.let {
+                val session = NovelUpdateCoordinator.awaitUpdateSlot(targetNovel.ncode)
+                if (session == null) {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "他の更新処理を待機中です"
+                        Toast.makeText(context, "他の更新処理が進行中です。時間を置いて再度お試しください。", Toast.LENGTH_SHORT).show()
+                        delay(1500)
+                        isUpdating = false
+                    }
+                    return@launch
+                }
+
+                suspend fun handleCancellation() {
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "処理が中断されました"
+                        Toast.makeText(context, "更新処理が中断されました", Toast.LENGTH_SHORT).show()
+                        delay(1500)
+                        isUpdating = false
+                    }
+                }
+
+                try {
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
+
+                    var successCount = 0
+                    var failCount = 0
+
+                    // スクレイピングの実行
                     for ((index, episodeNo) in redownloadTargets.withIndex()) {
-                        val episode = fetchEpisode(it.ncode, episodeNo, it.rating == 1, it.noveltype)
+                        if (session.isCancelled()) {
+                            handleCancellation()
+                            return@launch
+                        }
+
+                        val episode = fetchEpisode(targetNovel.ncode, episodeNo, targetNovel.rating == 1, targetNovel.noveltype)
 
                         if (episode != null) {
                             // データベースに保存
@@ -472,7 +659,7 @@ fun EpisodeListScreen(
                         }
 
                         // サーバーに負荷をかけないように少し待機
-                        delay(50) // 1秒待機
+                        delay(50)
 
                         // 進捗を更新
                         val progress = (index + 1).toFloat() / redownloadTargets.size
@@ -480,23 +667,30 @@ fun EpisodeListScreen(
                         updateMessage = "エラーまたは欠番のあるエピソードを再取得中... (${index + 1}/${redownloadTargets.size})"
                     }
 
+                    if (session.isCancelled()) {
+                        handleCancellation()
+                        return@launch
+                    }
+
                     // 小説のtotal_epを更新
-                    val updatedEpisodes = repository.getEpisodesByNcode(it.ncode).first()
+                    val updatedEpisodes = repository.getEpisodesByNcode(targetNovel.ncode).first()
                     val maxEpisodeNo = updatedEpisodes.mapNotNull { episode -> episode.episode_no.toIntOrNull() }.maxOrNull() ?: 0
 
-                    if (maxEpisodeNo > it.total_ep) {
-                        val updatedNovel = it.copy(total_ep = maxEpisodeNo)
+                    if (maxEpisodeNo > targetNovel.total_ep) {
+                        val updatedNovel = targetNovel.copy(total_ep = maxEpisodeNo)
                         repository.updateNovel(updatedNovel)
                     }
-                }
 
-                // 処理結果の通知
-                withContext(Dispatchers.Main) {
-                    updateProgress = 1f
-                    updateMessage = "完了: 成功${successCount}件、失敗${failCount}件"
-                    Toast.makeText(context, "完了: 成功${successCount}件、失敗${failCount}件", Toast.LENGTH_SHORT).show()
-                    delay(2000)
-                    isUpdating = false
+                    // 処理結果の通知
+                    withContext(Dispatchers.Main) {
+                        updateProgress = 1f
+                        updateMessage = "完了: 成功${successCount}件、失敗${failCount}件"
+                        Toast.makeText(context, "完了: 成功${successCount}件、失敗${failCount}件", Toast.LENGTH_SHORT).show()
+                        delay(2000)
+                        isUpdating = false
+                    }
+                } finally {
+                    NovelUpdateCoordinator.finishUpdate(session)
                 }
             } catch (e: Exception) {
                 // 例外発生

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateCheckWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateCheckWorker.kt
@@ -17,6 +17,7 @@ import com.shunlight_library.novel_reader.NovelReaderApplication
 import com.shunlight_library.novel_reader.R
 import com.shunlight_library.novel_reader.api.NovelApiUtils
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
+import com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -56,13 +57,29 @@ class UpdateCheckWorker(
 
             // 各小説の更新をチェック
             for (novel in novels) {
+                val session = NovelUpdateCoordinator.beginUpdate(novel.ncode)
+                if (session == null) {
+                    Log.d(TAG, "小説\"${novel.ncode}\"は他の処理中のためスキップします")
+                    continue
+                }
+
                 try {
+                    if (session.isCancelled()) {
+                        Log.d(TAG, "小説\"${novel.ncode}\"の更新確認はキャンセルされました")
+                        continue
+                    }
+
                     // APIから最新情報を取得
                     val info = NovelApiUtils.fetchNovelInfo(
                         novel.ncode,
                         novel.rating == 1
                     )
                     if (info != null) {
+                        if (session.isCancelled()) {
+                            Log.d(TAG, "小説\"${novel.ncode}\"の更新確認はキャンセルされました")
+                            continue
+                        }
+
                         // 常に最新情報を保存
                         val updatedNovel = novel.copy(
                             general_all_no = info.generalAllNo,
@@ -72,6 +89,11 @@ class UpdateCheckWorker(
                             length = novel.length ?: info.length
                         )
                         repository.updateNovel(updatedNovel)
+
+                        if (session.isCancelled()) {
+                            Log.d(TAG, "小説\"${novel.ncode}\"の更新確認はキャンセルされました")
+                            continue
+                        }
 
                         // 更新がある場合
                         if (info.generalAllNo > novel.general_all_no) {
@@ -98,6 +120,8 @@ class UpdateCheckWorker(
                 } catch (e: Exception) {
                     Log.e(TAG, "小説「${novel.title}」の更新チェック中にエラー: ${e.message}")
                     // 1つの小説のエラーで全体が失敗しないよう、継続する
+                } finally {
+                    NovelUpdateCoordinator.finishUpdate(session)
                 }
             }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -28,6 +28,7 @@ import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
 import com.shunlight_library.novel_reader.data.sync.DatabaseSyncUtils
+import com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Semaphore
@@ -520,153 +521,172 @@ fun UpdateInfoScreen(
                                                     val endEpisode = queueItem.general_all_no
 
                                                     if (startEpisode <= endEpisode) {
-                                                        // 更新状態を更新
                                                         syncMessage = "「${novel.title}」のエピソードを更新中..."
 
-                                                        // エピソードリストを作成
                                                         val episodesList = (startEpisode..endEpisode).toList()
+                                                        val session = NovelUpdateCoordinator.awaitUpdateSlot(queueItem.ncode)
+                                                        if (session == null) {
+                                                            val skipped = episodesList.size
+                                                            totalEpisodes -= skipped
+                                                            if (totalEpisodes < processedEpisodes) {
+                                                                totalEpisodes = processedEpisodes
+                                                            }
+                                                            val safeTotal = if (totalEpisodes <= 0) processedEpisodes else totalEpisodes
+                                                            totalCount = safeTotal
+                                                            syncProgress = if (safeTotal == 0) 1f else processedEpisodes.toFloat() / safeTotal.toFloat()
+                                                            syncMessage = "「${novel.title}」は他の更新処理中のためスキップしました"
+                                                            continue
+                                                        }
 
-                                                        // エピソードの取得とスクレイピング
                                                         val episodes = mutableListOf<EpisodeEntity>()
+                                                        var cancelledForNovel = false
+                                                        var processedForNovel = 0
 
-                                                        for (episodeNo in episodesList) {
-                                                            // 進捗状況の更新
-                                                            val episodeNoStr = episodeNo.toString()
-                                                            syncMessage = "「${novel.title}」の第${episodeNoStr}話を取得中..."
-
-                                                            try {
-                                                                // 小説のURLを構築（通常版またはR18版）
-                                                                val baseUrl = if (novel.rating == 1) {
-                                                                    "https://novel18.syosetu.com"
-                                                                } else {
-                                                                    "https://ncode.syosetu.com"
+                                                        try {
+                                                            for (episodeNo in episodesList) {
+                                                                if (session.isCancelled()) {
+                                                                    cancelledForNovel = true
+                                                                    break
                                                                 }
 
-                                                                val url = "$baseUrl/${queueItem.ncode}/$episodeNoStr/"
+                                                                val episodeNoStr = episodeNo.toString()
+                                                                syncMessage = "「${novel.title}」の第${episodeNoStr}話を取得中..."
 
-                                                                // JSoupを使用してスクレイピング
-                                                                // スクレイピング部分のコード修正
-                                                                withContext(Dispatchers.IO) {
-                                                                    connectionSemaphore.acquire()
-                                                                    try {
-                                                                        val baseUrl = if (novel.rating == 1) {
-                                                                            "https://novel18.syosetu.com"
-                                                                        } else {
-                                                                            "https://ncode.syosetu.com"
-                                                                        }
+                                                                try {
+                                                                    val baseUrl = if (novel.rating == 1) {
+                                                                        "https://novel18.syosetu.com"
+                                                                    } else {
+                                                                        "https://ncode.syosetu.com"
+                                                                    }
 
-                                                                        val url = "$baseUrl/${queueItem.ncode}/$episodeNoStr/"
+                                                                    val url = "$baseUrl/${queueItem.ncode}/$episodeNoStr/"
 
-                                                                        // リトライロジックを実装した関数を使用
-                                                                        val doc = fetchWithRetry(url)
+                                                                    withContext(Dispatchers.IO) {
+                                                                        connectionSemaphore.acquire()
+                                                                        try {
+                                                                            val baseUrl = if (novel.rating == 1) {
+                                                                                "https://novel18.syosetu.com"
+                                                                            } else {
+                                                                                "https://ncode.syosetu.com"
+                                                                            }
 
-                                                                        if (doc != null) {
-                                                                            try {
-                                                                                // タイトルの取得（text()でタグを除去）
-                                                                                var title = doc.select("h1.p-novel__title.p-novel__title--rensai").text()
-                                                                                val bodyElements = doc.select("div.p-novel__body > div")
-                                                                                val body = StringBuilder()
+                                                                            val url = "$baseUrl/${queueItem.ncode}/$episodeNoStr/"
 
-                                                                                if (bodyElements.isNotEmpty()) {
-                                                                                    bodyElements.forEachIndexed { index, element ->
-                                                                                        body.append(element.outerHtml())
-                                                                                        // 最後の要素でなければ<hr>を追加
-                                                                                        if (index < bodyElements.size - 1) {
-                                                                                            body.append("\n<hr>\n")
-                                                                                        }
-                                                                                    }
-                                                                                }
+                                                                            val doc = fetchWithRetry(url)
 
-                                                                                // タイトルまたは本文が空の場合はリトライ
-                                                                                if (title.isEmpty() || body.isEmpty()) {
-                                                                                    Log.d("UpdateInfo", "タイトルまたは本文が空のためリトライします: ${queueItem.ncode}-$episodeNoStr")
+                                                                            if (doc != null) {
+                                                                                try {
+                                                                                    var title = doc.select("h1.p-novel__title.p-novel__title--rensai").text()
+                                                                                    val bodyElements = doc.select("div.p-novel__body > div")
+                                                                                    val body = StringBuilder()
 
-                                                                                    // リトライロジック
-                                                                                    val retryDoc = fetchWithRetry(url)
-                                                                                    if (retryDoc != null) {
-                                                                                        // タイトルが空だった場合は再取得
-                                                                                        if (title.isEmpty()) {
-                                                                                            title = retryDoc.select("h1.p-novel__title.p-novel__title--rensai").text()
-                                                                                        }
-
-                                                                                        // 本文が空だった場合は再取得
-                                                                                        if (body.isEmpty()) {
-                                                                                            val bodyElements = doc.select("div.p-novel__body > div")
-                                                                                            val body = StringBuilder()
-
-                                                                                            if (bodyElements.isNotEmpty()) {
-                                                                                                bodyElements.forEachIndexed { index, element ->
-                                                                                                    body.append(element.outerHtml())
-                                                                                                    // 最後の要素でなければ<hr>を追加
-                                                                                                    if (index < bodyElements.size - 1) {
-                                                                                                        body.append("\n<hr>\n")
-                                                                                                    }
-                                                                                                }
+                                                                                    if (bodyElements.isNotEmpty()) {
+                                                                                        bodyElements.forEachIndexed { index, element ->
+                                                                                            body.append(element.outerHtml())
+                                                                                            if (index < bodyElements.size - 1) {
+                                                                                                body.append("\n<hr>\n")
                                                                                             }
                                                                                         }
                                                                                     }
+
+                                                                                    if (title.isEmpty() || body.isEmpty()) {
+                                                                                        Log.d("UpdateInfo", "タイトルまたは本文が空のためリトライします: ${queueItem.ncode}-$episodeNoStr")
+
+                                                                                        val retryDoc = fetchWithRetry(url)
+                                                                                        if (retryDoc != null) {
+                                                                                            if (title.isEmpty()) {
+                                                                                                title = retryDoc.select("h1.p-novel__title.p-novel__title--rensai").text()
+                                                                                            }
+
+                                                                                            if (body.isEmpty()) {
+                                                                                                val bodyElementsRetry = doc.select("div.p-novel__body > div")
+                                                                                                val bodyRetry = StringBuilder()
+
+                                                                                                if (bodyElementsRetry.isNotEmpty()) {
+                                                                                                    bodyElementsRetry.forEachIndexed { index, element ->
+                                                                                                        bodyRetry.append(element.outerHtml())
+                                                                                                        if (index < bodyElementsRetry.size - 1) {
+                                                                                                            bodyRetry.append("\n<hr>\n")
+                                                                                                        }
+                                                                                                    }
+                                                                                                }
+
+                                                                                                body.clear()
+                                                                                                body.append(bodyRetry)
+                                                                                            }
+                                                                                        }
+                                                                                    }
+
+                                                                                    if (title.isEmpty() || body.isEmpty()) {
+                                                                                        Log.e("UpdateInfo", "リトライ後も内容の取得に失敗: ${queueItem.ncode}-$episodeNoStr")
+                                                                                    }
+
+                                                                                    val now = Date()
+                                                                                    val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(now)
+
+                                                                                    val episode = EpisodeEntity(
+                                                                                        ncode = queueItem.ncode,
+                                                                                        episode_no = episodeNoStr,
+                                                                                        body = body.toString(),
+                                                                                        e_title = title,
+                                                                                        update_time = dateFormat
+                                                                                    )
+
+                                                                                    episodes.add(episode)
+
+                                                                                    Log.d("UpdateInfo", "エピソード取得成功: ${queueItem.ncode}-$episodeNoStr")
+                                                                                } catch (e: Exception) {
+                                                                                    Log.e("UpdateInfo", "エピソード解析エラー: ${queueItem.ncode}-$episodeNoStr", e)
                                                                                 }
-
-                                                                                // それでも空の場合はエラー記録して次へ
-                                                                                if (title.isEmpty() || body.isEmpty()) {
-                                                                                    Log.e("UpdateInfo", "リトライ後も内容の取得に失敗: ${queueItem.ncode}-$episodeNoStr")
-
-                                                                                }
-
-                                                                                // 更新日時の取得
-                                                                                val now = Date()
-                                                                                val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(now)
-
-                                                                                // EpisodeEntityの作成（titleはtext()でタグ除去済み、bodyはhtml()でタグ保持）
-                                                                                val episode = EpisodeEntity(
-                                                                                    ncode = queueItem.ncode,
-                                                                                    episode_no = episodeNoStr,
-                                                                                    body = body.toString(),
-                                                                                    e_title = title,
-                                                                                    update_time = dateFormat
-                                                                                )
-
-                                                                                episodes.add(episode)
-
-                                                                                // 成功ログ
-                                                                                Log.d("UpdateInfo", "エピソード取得成功: ${queueItem.ncode}-$episodeNoStr")
-                                                                            } catch (e: Exception) {
-                                                                                // 解析エラー
-                                                                                Log.e("UpdateInfo", "エピソード解析エラー: ${queueItem.ncode}-$episodeNoStr", e)
+                                                                            } else {
+                                                                                Log.e("UpdateInfo", "エピソード取得失敗: ${queueItem.ncode}-$episodeNoStr")
                                                                             }
-                                                                        } else {
-                                                                            // 取得失敗ログ
-                                                                            Log.e("UpdateInfo", "エピソード取得失敗: ${queueItem.ncode}-$episodeNoStr")
+                                                                        } finally {
+                                                                            connectionSemaphore.release()
                                                                         }
-                                                                    } finally {
-                                                                        connectionSemaphore.release() // 必ず解放
                                                                     }
+
+                                                                    processedEpisodes++
+                                                                    processedForNovel++
+                                                                    currentCount = processedEpisodes
+                                                                    val safeTotal = if (totalEpisodes <= 0) processedEpisodes else totalEpisodes
+                                                                    totalCount = safeTotal
+                                                                    syncProgress = if (safeTotal == 0) 1f else processedEpisodes.toFloat() / safeTotal.toFloat()
+
+                                                                } catch (e: Exception) {
+                                                                    Log.e("UpdateInfo", "エピソード取得エラー: ${queueItem.ncode}-$episodeNoStr", e)
                                                                 }
 
-                                                                // 進捗を更新
-                                                                processedEpisodes++
-                                                                currentCount = processedEpisodes
-                                                                syncProgress = processedEpisodes.toFloat() / totalEpisodes
-
-                                                            } catch (e: Exception) {
-                                                                Log.e("UpdateInfo", "エピソード取得エラー: ${queueItem.ncode}-$episodeNoStr", e)
-                                                                // エラーは記録するが処理は継続
+                                                                delay(100)
                                                             }
 
-                                                            // UIの反応性を向上させるための短い遅延
-                                                            delay(100)
-                                                        }
+                                                            if (!cancelledForNovel && session.isCancelled()) {
+                                                                cancelledForNovel = true
+                                                            }
 
-                                                        // バッチで保存
-                                                        if (episodes.isNotEmpty()) {
-                                                            repository.insertEpisodes(episodes)
+                                                            if (cancelledForNovel) {
+                                                                val remaining = episodesList.size - processedForNovel
+                                                                totalEpisodes -= remaining
+                                                                if (totalEpisodes < processedEpisodes) {
+                                                                    totalEpisodes = processedEpisodes
+                                                                }
+                                                                val safeTotal = if (totalEpisodes <= 0) processedEpisodes else totalEpisodes
+                                                                totalCount = safeTotal
+                                                                syncProgress = if (safeTotal == 0) 1f else processedEpisodes.toFloat() / safeTotal.toFloat()
+                                                                syncMessage = "「${novel.title}」の更新は中断されました"
+                                                                continue
+                                                            }
 
-                                                            // 小説のtotal_epを更新
-                                                            val updatedNovel = novel.copy(total_ep = endEpisode)
-                                                            repository.updateNovel(updatedNovel)
+                                                            if (episodes.isNotEmpty()) {
+                                                                repository.insertEpisodes(episodes)
 
-                                                            // 更新キューから削除
-                                                            repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                                                                val updatedNovel = novel.copy(total_ep = endEpisode)
+                                                                repository.updateNovel(updatedNovel)
+
+                                                                repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                                                            }
+                                                        } finally {
+                                                            NovelUpdateCoordinator.finishUpdate(session)
                                                         }
                                                     }
                                                 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator
 
 class NovelRepository(
     private val episodeDao: EpisodeDao,
@@ -124,6 +125,10 @@ class NovelRepository(
     }
 
     suspend fun deleteNovelWithRelations(novel: NovelDescEntity) {
+        val stopped = NovelUpdateCoordinator.cancelAndWait(novel.ncode)
+        if (!stopped) {
+            throw IllegalStateException("進行中の更新を停止できませんでした: ${novel.ncode}")
+        }
         withContext(Dispatchers.IO) {
             episodeDao.deleteEpisodesByNcode(novel.ncode)
             lastReadNovelDao.getLastReadByNcode(novel.ncode)?.let {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
@@ -22,6 +22,7 @@ import com.shunlight_library.novel_reader.api.NovelApiUtils
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.first
+import com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -65,6 +66,7 @@ class UpdateService : Service() {
     private var isRunning = false
     private var updateType = 0
     private var currentNcode = ""
+    private var currentUpdateSession: NovelUpdateCoordinator.UpdateSession? = null
     private var updateListeners = mutableListOf<UpdateProgressListener>()
 
     // Interface for progress updates
@@ -159,7 +161,12 @@ class UpdateService : Service() {
     }
 
     private fun updateComplete(success: Boolean, resultMessage: String) {
+        currentUpdateSession?.let {
+            NovelUpdateCoordinator.finishUpdate(it)
+            currentUpdateSession = null
+        }
         isRunning = false
+        currentNcode = ""
         updateListeners.forEach { it.onUpdateComplete(success, resultMessage) }
 
         // Update notification one last time
@@ -183,9 +190,14 @@ class UpdateService : Service() {
 
     private fun stopUpdate() {
         if (isRunning) {
-            // Cancel ongoing operations
+            currentUpdateSession?.cancel()
+            val ncodeToCancel = currentNcode
+            if (ncodeToCancel.isNotEmpty()) {
+                serviceScope.launch {
+                    NovelUpdateCoordinator.cancelAndWait(ncodeToCancel)
+                }
+            }
             isRunning = false
-            updateComplete(false, "更新処理がキャンセルされました")
         }
     }
 
@@ -235,13 +247,32 @@ class UpdateService : Service() {
     // UpdateService.kt の checkForUpdates メソッドを修正
     private fun checkForUpdates(ncode: String) {
         serviceScope.launch {
+            val session = NovelUpdateCoordinator.beginUpdate(ncode)
+            if (session == null) {
+                updateComplete(false, "この小説はすでに更新処理中です")
+                return@launch
+            }
+
+            currentUpdateSession = session
+            currentNcode = ncode
+
             try {
                 updateProgress(0.1f, "APIで最新情報を確認中...")
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Get current novel info
                 val novel = repository.getNovelByNcode(ncode)
                 if (novel == null) {
                     updateComplete(false, "小説情報が見つかりませんでした")
+                    return@launch
+                }
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
                     return@launch
                 }
 
@@ -254,6 +285,11 @@ class UpdateService : Service() {
                     isR18 = novel.rating == 1,
                     apiUrl = urlEntity.api_url
                 )
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 if (info == null) {
                     updateComplete(false, "APIからデータが取得できませんでした")
@@ -269,6 +305,11 @@ class UpdateService : Service() {
                     length = novel.length ?: info.length
                 )
                 repository.updateNovel(updatedNovel)
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Check if update is available
                 if (info.generalAllNo > novel.general_all_no) {
@@ -288,13 +329,34 @@ class UpdateService : Service() {
             } catch (e: Exception) {
                 Log.e(TAG, "Update check error", e)
                 updateComplete(false, "エラー: ${e.message}")
+            } finally {
+                if (currentUpdateSession === session) {
+                    NovelUpdateCoordinator.finishUpdate(session)
+                    currentUpdateSession = null
+                } else {
+                    NovelUpdateCoordinator.finishUpdate(session)
+                }
             }
         }
     }
     private fun downloadEpisodes(ncode: String) {
         serviceScope.launch {
+            val session = NovelUpdateCoordinator.beginUpdate(ncode)
+            if (session == null) {
+                updateComplete(false, "この小説はすでに更新処理中です")
+                return@launch
+            }
+
+            currentUpdateSession = session
+            currentNcode = ncode
+
             try {
                 updateProgress(0.1f, "小説情報を取得中...")
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Get novel info
                 val novel = repository.getNovelByNcode(ncode)
@@ -303,10 +365,20 @@ class UpdateService : Service() {
                     return@launch
                 }
 
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
+
                 updateProgress(0.2f, "APIで最新情報を確認中...")
 
                 // Get latest info from API
                 val info = NovelApiUtils.fetchNovelInfo(ncode, novel.rating == 1)
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 var generalAllNoValue = info?.generalAllNo ?: novel.general_all_no
                 val newUpdatedAt = info?.updatedAt ?: novel.updated_at
@@ -318,6 +390,11 @@ class UpdateService : Service() {
                     length = novel.length ?: info?.length
                 )
                 repository.updateNovel(updatedNovel)
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Start downloading episodes
                 updateProgress(0.3f, "エピソードを取得中... (0/$generalAllNoValue)")
@@ -335,8 +412,10 @@ class UpdateService : Service() {
                 }
 
                 for ((index, episodeNo) in episodesToDownload.withIndex()) {
-                    // Check if service is still running
-                    if (!isRunning) break
+                    if (!isRunning || session.isCancelled()) {
+                        updateComplete(false, "更新処理が中断されました")
+                        return@launch
+                    }
 
                     val episode = NovelApiUtils.fetchEpisode(
                         novel.ncode,
@@ -360,17 +439,22 @@ class UpdateService : Service() {
                     delay(200)
                 }
 
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
+
                 // Update novel total_ep value
                 if (successCount > 0) {
-                    val updatedNovel = novel.copy(
+                    val updatedNovelAfterDownload = novel.copy(
                         total_ep = novel.total_ep + successCount,
                         general_all_no = generalAllNoValue,
                         updated_at = newUpdatedAt
                     )
-                    repository.updateNovel(updatedNovel)
+                    repository.updateNovel(updatedNovelAfterDownload)
 
                     // Remove from update queue if all episodes downloaded
-                    if (updatedNovel.total_ep >= generalAllNoValue) {
+                    if (updatedNovelAfterDownload.total_ep >= generalAllNoValue) {
                         repository.deleteUpdateQueueByNcode(ncode)
                     }
                 }
@@ -379,14 +463,35 @@ class UpdateService : Service() {
             } catch (e: Exception) {
                 Log.e(TAG, "Download episodes error", e)
                 updateComplete(false, "エラー: ${e.message}")
+            } finally {
+                if (currentUpdateSession === session) {
+                    NovelUpdateCoordinator.finishUpdate(session)
+                    currentUpdateSession = null
+                } else {
+                    NovelUpdateCoordinator.finishUpdate(session)
+                }
             }
         }
     }
 
     private fun fixEpisodeErrors(ncode: String) {
         serviceScope.launch {
+            val session = NovelUpdateCoordinator.beginUpdate(ncode)
+            if (session == null) {
+                updateComplete(false, "この小説はすでに更新処理中です")
+                return@launch
+            }
+
+            currentUpdateSession = session
+            currentNcode = ncode
+
             try {
                 updateProgress(0.1f, "エピソードをチェック中...")
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Get novel info
                 val novel = repository.getNovelByNcode(ncode)
@@ -395,8 +500,18 @@ class UpdateService : Service() {
                     return@launch
                 }
 
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
+
                 // Get episodes
                 val episodes = repository.getEpisodesByNcode(ncode).first()
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Find episodes with errors
                 val errorEpisodes = episodes.filter { episode ->
@@ -405,8 +520,18 @@ class UpdateService : Service() {
 
                 updateProgress(0.2f, "APIで最新情報を確認中...")
 
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
+
                 // Get latest info from API
                 val info = NovelApiUtils.fetchNovelInfo(ncode, novel.rating == 1)
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 var generalAllNoValue = info?.generalAllNo ?: novel.general_all_no
                 val updatedNovel = novel.copy(
@@ -417,6 +542,11 @@ class UpdateService : Service() {
                     length = novel.length ?: info?.length
                 )
                 repository.updateNovel(updatedNovel)
+
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Find missing episodes
                 val episodeNumberMap = episodes.associate { episode ->
@@ -446,8 +576,10 @@ class UpdateService : Service() {
 
                 // Download error episodes
                 for ((index, episodeNo) in redownloadTargets.withIndex()) {
-                    // Check if service is still running
-                    if (!isRunning) break
+                    if (!isRunning || session.isCancelled()) {
+                        updateComplete(false, "更新処理が中断されました")
+                        return@launch
+                    }
 
                     val episode = NovelApiUtils.fetchEpisode(
                         novel.ncode,
@@ -466,8 +598,11 @@ class UpdateService : Service() {
                     // Update progress
                     val progress = (index + 1).toFloat() / redownloadTargets.size
                     updateProgress(0.3f + (0.7f * progress), "エラーまたは欠番のあるエピソードを再取得中... (${index + 1}/${redownloadTargets.size})")
+                }
 
-
+                if (!isRunning || session.isCancelled()) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
                 }
 
                 // Update novel total_ep value if needed
@@ -475,14 +610,21 @@ class UpdateService : Service() {
                 val maxEpisodeNoAfterFix = updatedEpisodes.mapNotNull { it.episode_no.toIntOrNull() }.maxOrNull() ?: 0
 
                 if (maxEpisodeNoAfterFix > novel.total_ep) {
-                    val updatedNovel = novel.copy(total_ep = maxEpisodeNoAfterFix)
-                    repository.updateNovel(updatedNovel)
+                    val updatedNovelAfterFix = novel.copy(total_ep = maxEpisodeNoAfterFix)
+                    repository.updateNovel(updatedNovelAfterFix)
                 }
 
                 updateComplete(true, "完了: 成功${successCount}件、失敗${failCount}件")
             } catch (e: Exception) {
                 Log.e(TAG, "Fix episodes error", e)
                 updateComplete(false, "エラー: ${e.message}")
+            } finally {
+                if (currentUpdateSession === session) {
+                    NovelUpdateCoordinator.finishUpdate(session)
+                    currentUpdateSession = null
+                } else {
+                    NovelUpdateCoordinator.finishUpdate(session)
+                }
             }
         }
     }
@@ -491,6 +633,11 @@ class UpdateService : Service() {
         serviceScope.launch {
             try {
                 updateProgress(0.1f, "更新キューを取得中...")
+
+                if (!isRunning) {
+                    updateComplete(false, "更新処理が中断されました")
+                    return@launch
+                }
 
                 // Get update queue
                 val updateQueue = repository.getAllUpdateQueue()
@@ -502,13 +649,15 @@ class UpdateService : Service() {
 
                 updateProgress(0.2f, "更新対象を計算中...")
 
-                // Count total episodes to download
+                // Count total episodes to download and prepare plan
                 var totalEpisodes = 0
+                val plannedEpisodes = mutableMapOf<String, Int>()
                 updateQueue.forEach { queueItem ->
                     val novel = repository.getNovelByNcode(queueItem.ncode)
                     if (novel != null) {
                         val episodesToDownload = queueItem.general_all_no - novel.total_ep
                         if (episodesToDownload > 0) {
+                            plannedEpisodes[queueItem.ncode] = episodesToDownload
                             totalEpisodes += episodesToDownload
                         }
                     }
@@ -524,32 +673,55 @@ class UpdateService : Service() {
                 var processedEpisodes = 0
                 var successCount = 0
                 var failCount = 0
+                val skippedNovels = mutableSetOf<String>()
 
                 // Process each queue item
                 for (queueItem in updateQueue) {
-                    // Check if service is still running
-                    if (!isRunning) break
-
-                    val novel = repository.getNovelByNcode(queueItem.ncode)
-                    if (novel == null) {
-                        continue
+                    if (!isRunning) {
+                        updateComplete(false, "更新処理が中断されました")
+                        return@launch
                     }
 
-                    // Update progress with current novel info
-                    updateProgress(
-                        0.3f + (0.7f * processedEpisodes.toFloat() / totalEpisodes),
-                        "「${novel.title}」のエピソードをダウンロード中..."
-                    )
+                    val novel = repository.getNovelByNcode(queueItem.ncode) ?: continue
+                    val plannedCount = plannedEpisodes[queueItem.ncode] ?: continue
+                    if (plannedCount <= 0) continue
 
                     val startEpisode = novel.total_ep + 1
                     val endEpisode = queueItem.general_all_no
+                    if (startEpisode > endEpisode) {
+                        continue
+                    }
 
-                    if (startEpisode <= endEpisode) {
-                        val episodesToDownload = (startEpisode..endEpisode).toList()
+                    val session = NovelUpdateCoordinator.awaitUpdateSlot(queueItem.ncode)
+                    if (session == null) {
+                        skippedNovels.add(queueItem.ncode)
+                        totalEpisodes -= plannedCount
+                        if (totalEpisodes < processedEpisodes) {
+                            totalEpisodes = processedEpisodes
+                        }
+                        continue
+                    }
 
+                    currentUpdateSession = session
+                    currentNcode = queueItem.ncode
+
+                    val episodesToDownload = (startEpisode..endEpisode).toList()
+                    var processedForNovel = 0
+                    var successForNovel = 0
+                    var failForNovel = 0
+                    var cancelledForNovel = false
+
+                    try {
                         for (episodeNo in episodesToDownload) {
-                            // Check if service is still running
-                            if (!isRunning) break
+                            if (!isRunning) {
+                                updateComplete(false, "更新処理が中断されました")
+                                return@launch
+                            }
+
+                            if (session.isCancelled()) {
+                                cancelledForNovel = true
+                                break
+                            }
 
                             val episode = NovelApiUtils.fetchEpisode(
                                 novel.ncode,
@@ -560,39 +732,73 @@ class UpdateService : Service() {
 
                             if (episode != null) {
                                 repository.insertEpisode(episode)
-                                successCount++
+                                successForNovel++
                             } else {
-                                failCount++
+                                failForNovel++
                             }
 
+                            processedForNovel++
                             processedEpisodes++
 
-                            // Update progress
+                            val denominator = if (totalEpisodes <= 0) {
+                                if (processedEpisodes == 0) 1 else processedEpisodes
+                            } else {
+                                maxOf(totalEpisodes, processedEpisodes)
+                            }
+                            val fraction = processedEpisodes.toFloat() / denominator.toFloat()
                             updateProgress(
-                                0.3f + (0.7f * processedEpisodes.toFloat() / totalEpisodes),
-                                "エピソードをダウンロード中... ($processedEpisodes/$totalEpisodes)"
+                                0.3f + (0.7f * fraction),
+                                "エピソードをダウンロード中... ($processedEpisodes/$denominator)"
                             )
 
                             // Avoid server overload
                             delay(200)
                         }
-
-                        // Update novel info
-                        val updatedNovel = novel.copy(
-                            total_ep = endEpisode,
-                            general_all_no = endEpisode
-                        )
-                        repository.updateNovel(updatedNovel)
-
-                        // Remove from update queue
-                        repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                    } finally {
+                        NovelUpdateCoordinator.finishUpdate(session)
+                        if (currentUpdateSession === session) {
+                            currentUpdateSession = null
+                        }
                     }
+
+                    if (cancelledForNovel) {
+                        skippedNovels.add(queueItem.ncode)
+                        val remaining = episodesToDownload.size - processedForNovel
+                        totalEpisodes -= remaining
+                        if (totalEpisodes < processedEpisodes) {
+                            totalEpisodes = processedEpisodes
+                        }
+                        continue
+                    }
+
+                    successCount += successForNovel
+                    failCount += failForNovel
+
+                    // Update novel info
+                    val updatedNovel = novel.copy(
+                        total_ep = endEpisode,
+                        general_all_no = endEpisode
+                    )
+                    repository.updateNovel(updatedNovel)
+
+                    // Remove from update queue
+                    repository.deleteUpdateQueueByNcode(queueItem.ncode)
                 }
 
-                updateComplete(true, "完了: 成功${successCount}件、失敗${failCount}件")
+                val message = if (skippedNovels.isEmpty()) {
+                    "完了: 成功${successCount}件、失敗${failCount}件"
+                } else {
+                    "完了: 成功${successCount}件、失敗${failCount}件（${skippedNovels.size}件の小説をスキップ）"
+                }
+                updateComplete(true, message)
             } catch (e: Exception) {
                 Log.e(TAG, "Bulk update error", e)
                 updateComplete(false, "エラー: ${e.message}")
+            } finally {
+                currentUpdateSession?.let {
+                    NovelUpdateCoordinator.finishUpdate(it)
+                    currentUpdateSession = null
+                }
             }
         }
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/NovelUpdateCoordinator.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/NovelUpdateCoordinator.kt
@@ -1,0 +1,126 @@
+package com.shunlight_library.novel_reader.utils
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Coordinates concurrent update operations to ensure a single update per ncode.
+ */
+object NovelUpdateCoordinator {
+    private const val DEFAULT_TIMEOUT_MS = 30_000L
+    private const val DEFAULT_CHECK_INTERVAL_MS = 100L
+
+    private val mutex = Mutex()
+    private val activeUpdates = ConcurrentHashMap<String, UpdateSession>()
+
+    /**
+     * Attempts to reserve the update slot for the given ncode. Returns null if already taken.
+     */
+    suspend fun beginUpdate(ncode: String): UpdateSession? {
+        if (ncode.isBlank()) return null
+        return mutex.withLock {
+            if (activeUpdates.containsKey(ncode)) {
+                null
+            } else {
+                UpdateSession(ncode).also { activeUpdates[ncode] = it }
+            }
+        }
+    }
+
+    /**
+     * Waits until the update slot becomes available (or timeout) and then reserves it.
+     */
+    suspend fun awaitUpdateSlot(
+        ncode: String,
+        timeoutMillis: Long = DEFAULT_TIMEOUT_MS,
+        checkIntervalMillis: Long = DEFAULT_CHECK_INTERVAL_MS
+    ): UpdateSession? {
+        if (ncode.isBlank()) return null
+
+        suspend fun waitForSlot(): UpdateSession {
+            while (true) {
+                beginUpdate(ncode)?.let { return it }
+                delay(checkIntervalMillis)
+            }
+        }
+
+        return if (timeoutMillis == Long.MAX_VALUE) {
+            waitForSlot()
+        } else {
+            withTimeoutOrNull(timeoutMillis) { waitForSlot() }
+        }
+    }
+
+    /**
+     * Releases the reserved update slot.
+     */
+    fun finishUpdate(session: UpdateSession?) {
+        session ?: return
+        session.markFinished()
+        activeUpdates.remove(session.ncode, session)
+    }
+
+    /**
+     * Requests cancellation for the ongoing update with the given ncode.
+     */
+    fun cancelUpdate(ncode: String) {
+        if (ncode.isBlank()) return
+        activeUpdates[ncode]?.cancel()
+    }
+
+    /**
+     * Cancels the ongoing update (if any) and waits for it to finish.
+     * Returns false if the slot did not finish within the timeout.
+     */
+    suspend fun cancelAndWait(
+        ncode: String,
+        timeoutMillis: Long = DEFAULT_TIMEOUT_MS
+    ): Boolean {
+        if (ncode.isBlank()) return true
+        val session = activeUpdates[ncode] ?: return true
+        session.cancel()
+        return session.awaitCompletion(timeoutMillis)
+    }
+
+    /**
+     * Checks whether an update is currently running for the given ncode.
+     */
+    fun isUpdating(ncode: String): Boolean {
+        if (ncode.isBlank()) return false
+        return activeUpdates.containsKey(ncode)
+    }
+
+    class UpdateSession internal constructor(val ncode: String) {
+        private val cancelled = AtomicBoolean(false)
+        private val completion = CompletableDeferred<Unit>()
+
+        fun cancel() {
+            cancelled.set(true)
+        }
+
+        fun isCancelled(): Boolean = cancelled.get()
+
+        internal suspend fun awaitCompletion(timeoutMillis: Long): Boolean {
+            return if (timeoutMillis == Long.MAX_VALUE) {
+                completion.await()
+                true
+            } else {
+                withTimeoutOrNull(timeoutMillis) {
+                    completion.await()
+                    true
+                } ?: false
+            }
+        }
+
+        internal fun markFinished() {
+            if (!completion.isCompleted) {
+                completion.complete(Unit)
+            }
+        }
+    }
+}

--- a/WORK_LOG.md
+++ b/WORK_LOG.md
@@ -364,3 +364,22 @@
 
 **効果**: 古い通知が自動的に整理され、メモリ使用量とDataStoreサイズの膨張を防止
 
+## 2025/10/05
+### 更新処理の排他制御とキャンセル待機を強化
+
+**問題**: 同一ncodeの更新が並行して進行するとデータ不整合が発生する恐れがあり、削除や再取得を実行した際に進行中の更新が完全に停止するまで待機できていなかった。
+
+**解決策**:
+- `NovelUpdateCoordinator` に `cancelAndWait` と完了通知機構を追加し、キャンセル後に確実にスロット解放を待機
+- `EpisodeListScreen` の再取得・ダウンロード・エラー修正処理で更新停止待機を挟み、停止できない場合はユーザーへ警告表示
+- `NovelRepository.deleteNovelWithRelations` が進行中の更新停止を確認できた場合のみ削除を続行するように調整
+
+**変更ファイル**:
+- `NovelUpdateCoordinator.kt`
+- `EpisodeListScreen.kt`
+- `UpdateService.kt`
+- `NovelRepository.kt`
+- `WORK_LOG.md`
+
+**効果**: バックグラウンド更新とユーザー操作の競合を安全に解決し、同一ncodeに対する重複更新や削除時の整合性崩れを防止
+


### PR DESCRIPTION
## Summary
- add cancellation completion tracking to NovelUpdateCoordinator and expose a cancel-and-wait helper
- wait for running updates to stop before reruns in EpisodeListScreen and UpdateService, surfacing errors to the user when cancellation fails
- block novel deletion until active updates finish and document the new workflow in WORK_LOG.md

## Testing
- not run (Gradle wrapper not present in repository)


------
https://chatgpt.com/codex/tasks/task_e_68e1eb8c0eb0832287c0f97f0a0b8831