### PR TITLE
GZIP圧縮レスポンスの解凍処理を修正

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -143,11 +143,21 @@ object NovelApiUtils {
                     return@withContext null
                 }
 
-                val useGzip = connection.contentEncoding?.contains("gzip", ignoreCase = true) == true
-                val inputStream = if (useGzip) {
-                    GZIPInputStream(connection.inputStream)
-                } else {
-                    connection.inputStream
+                // URLにgzipパラメータが含まれている、またはContent-Encodingヘッダーにgzipが含まれている場合はGZIP解凍
+                val useGzip = url.contains("gzip=", ignoreCase = true) ||
+                              connection.contentEncoding?.contains("gzip", ignoreCase = true) == true
+
+                Log.d(TAG, "GZIP使用: $useGzip (URL: $url, Content-Encoding: ${connection.contentEncoding})")
+
+                val inputStream = try {
+                    if (useGzip) {
+                        GZIPInputStream(connection.inputStream)
+                    } else {
+                        connection.inputStream
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "GZIP解凍エラー: ${e.message}", e)
+                    throw e
                 }
 
                 inputStream.buffered().use { bufferedStream ->


### PR DESCRIPTION
MalformedJsonExceptionの根本原因を修正:
- URLに「gzip=」パラメータが含まれている場合は常にGZIP解凍
- Content-Encodingヘッダーのチェックも継続（両方をOR条件で判定）
- GZIP解凍処理にエラーハンドリングを追加
- 解凍判定の詳細ログを追加

なろう小説APIは「gzip=5」パラメータを使用すると常にgzip圧縮されたデータを返すが、
Content-Encodingヘッダーが付かない場合があるため、URLパラメータで判定する必要がある。