### PR TITLE
Update display format for new content counts

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -160,7 +160,7 @@ fun NovelReaderApp(
     var currentEpisodeNo by remember { mutableStateOf("") }
     // R18コンテンツ用のダイアログ表示状態
     var showR18Dialog by remember { mutableStateOf(false) }
-    var updateInfoText by remember { mutableStateOf("新着0件0話") }
+    var updateInfoText by remember { mutableStateOf("0作品0話") }
     var showRecentlyReadNovels by remember { mutableStateOf(false) }
     var showRecentlyUpdatedNovelsScreen by remember { mutableStateOf(false) }
     // URLを開くヘルパー関数を修正
@@ -200,8 +200,8 @@ fun NovelReaderApp(
         }
 
         // 更新情報も取得
-        val (newCount, episodeCount) = repository.getUpdateCountsWithEpisodes()
-        updateInfoText = "新着${newCount}件${episodeCount}話"
+        val (workCount, episodeCount) = repository.getUpdateCountsWithEpisodes()
+        updateInfoText = "${workCount}作品${episodeCount}話"
     }
 
     // R18コンテンツ選択ダイアログ
@@ -441,7 +441,7 @@ fun MainScreen(
     // 状態変数
     var lastReadNovel by remember { mutableStateOf<LastReadNovelEntity?>(null) }
     var novelInfo by remember { mutableStateOf<NovelDescEntity?>(null) }
-    var updateInfoText by remember { mutableStateOf("新着0件0話") }
+    var updateInfoText by remember { mutableStateOf("0作品0話") }
     var showR18Dialog by remember { mutableStateOf(false) }
 
     // 通知関連の状態
@@ -503,8 +503,8 @@ fun MainScreen(
         }
 
         // 更新情報も取得
-        val (newCount, episodeCount) = repository.getUpdateCountsWithEpisodes()
-        updateInfoText = "新着${newCount}件${episodeCount}話"
+        val (workCount, episodeCount) = repository.getUpdateCountsWithEpisodes()
+        updateInfoText = "${workCount}作品${episodeCount}話"
     }
 
     // R18コンテンツ選択ダイアログ

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateCheckWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateCheckWorker.kt
@@ -52,8 +52,8 @@ class UpdateCheckWorker(
             // 通知チャンネルの作成
             createNotificationChannel()
 
-            var episodeCount = 0  // 更新された話数の合計
-            var newCount = 0  // 新着作品数
+            var workCount = 0  // 新着・更新された作品数
+            var episodeCount = 0  // 新着・更新された話数の合計
 
             // 各小説の更新をチェック
             for (novel in novels) {
@@ -105,10 +105,13 @@ class UpdateCheckWorker(
                             )
                             repository.insertUpdateQueue(updateQueue)
 
+                            workCount++
+
                             if (novel.general_all_no == 0) {
-                                newCount++
+                                // 新着作品：全話数を加算
+                                episodeCount += info.generalAllNo
                             } else {
-                                // 更新された話数を加算
+                                // 更新作品：新しく追加された話数を加算
                                 episodeCount += (info.generalAllNo - novel.general_all_no)
                             }
 
@@ -127,11 +130,11 @@ class UpdateCheckWorker(
             }
 
             // 更新があれば通知を送信
-            if (newCount > 0 || episodeCount > 0) {
-                sendUpdateNotification(newCount, episodeCount)
+            if (workCount > 0) {
+                sendUpdateNotification(workCount, episodeCount)
             }
 
-            Log.d(TAG, "自動更新チェック完了: 新着${newCount}件、${episodeCount}話")
+            Log.d(TAG, "自動更新チェック完了: ${workCount}作品、${episodeCount}話")
             Result.success()
         } catch (e: Exception) {
             Log.e(TAG, "自動更新チェック処理中にエラー: ${e.message}", e)
@@ -152,7 +155,7 @@ class UpdateCheckWorker(
     }
 
     @SuppressLint("MissingPermission")
-    private fun sendUpdateNotification(newCount: Int, episodeCount: Int) {
+    private fun sendUpdateNotification(workCount: Int, episodeCount: Int) {
         try {
             val notificationManager = NotificationManagerCompat.from(context)
 
@@ -160,7 +163,7 @@ class UpdateCheckWorker(
             val notification = NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_launcher_foreground)
                 .setContentTitle("小説の更新があります")
-                .setContentText("新着${newCount}件${episodeCount}話の更新が見つかりました")
+                .setContentText("${workCount}作品${episodeCount}話の更新が見つかりました")
                 .setPriority(NotificationCompat.PRIORITY_DEFAULT)
                 .setGroup(NOTIFICATION_GROUP_ID)
                 .setAutoCancel(true)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -242,8 +242,8 @@ fun UpdateInfoScreen(
                                 val novelBatches = novels.chunked(batchSize)
 
                                 var processedNovels = 0
-                                var newCount = 0
-                                var episodeCount = 0  // 更新された話数の合計
+                                var workCount = 0  // 新着・更新された作品数
+                                var episodeCount = 0  // 新着・更新された話数の合計
 
                                 // 各バッチを処理
                                 for (batch in novelBatches) {
@@ -281,10 +281,13 @@ fun UpdateInfoScreen(
                                                         )
                                                         repository.insertUpdateQueue(updateQueue)
 
+                                                        workCount++
+
                                                         if (novel.general_all_no == 0) {
-                                                            newCount++
+                                                            // 新着作品：全話数を加算
+                                                            episodeCount += info.generalAllNo
                                                         } else {
-                                                            // 更新された話数を加算
+                                                            // 更新作品：新しく追加された話数を加算
                                                             episodeCount += (info.generalAllNo - novel.general_all_no)
                                                         }
 
@@ -316,8 +319,8 @@ fun UpdateInfoScreen(
                                     updateProgress(totalCount, "更新チェック完了")
 
                                     // 結果を表示
-                                    val resultMessage = if (newCount > 0 || episodeCount > 0) {
-                                        "新着${newCount}件${episodeCount}話の更新が見つかりました"
+                                    val resultMessage = if (workCount > 0) {
+                                        "${workCount}作品${episodeCount}話の更新が見つかりました"
                                     } else {
                                         "更新された小説はありませんでした"
                                     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -160,19 +160,25 @@ class NovelRepository(
         return Pair(newCount, updateCount)
     }
 
-    // データベースからUpdate_queueの新着作品数と更新話数の合計を取得するメソッド
+    // データベースからUpdate_queueの作品数と話数の合計を取得するメソッド
     suspend fun getUpdateCountsWithEpisodes(): Pair<Int, Int> {
         val allQueue = updateQueueDao.getAllUpdateQueueList()
 
-        // 新規追加作品数
-        val newCount = allQueue.count { it.general_all_no == it.total_ep }
+        // 新着・更新を含む総作品数
+        val totalWorks = allQueue.size
 
-        // 更新された話数の合計（新規追加作品を除く）
-        val totalEpisodes = allQueue
-            .filter { it.general_all_no < it.total_ep }
-            .sumOf { it.total_ep - it.general_all_no }
+        // 新着作品の全話数 + 更新された話数の合計
+        val totalEpisodes = allQueue.sumOf { queue ->
+            if (queue.general_all_no == queue.total_ep) {
+                // 新着作品：全話数を加算
+                queue.total_ep
+            } else {
+                // 更新作品：新しく追加された話数のみを加算
+                queue.total_ep - queue.general_all_no
+            }
+        }
 
-        return Pair(newCount, totalEpisodes)
+        return Pair(totalWorks, totalEpisodes)
     }
     suspend fun getAllUpdateQueue(): List<UpdateQueueEntity> {
         return withContext(Dispatchers.IO) {


### PR DESCRIPTION
- 「新着n件・更新ありm件」から「新着n件m話」の形式に変更
- 更新のある作品数ではなく、更新された話数の合計を表示
- NovelRepository.ktに新しいgetUpdateCountsWithEpisodesメソッドを追加
- MainActivity.kt、UpdateCheckWorker.kt、UpdateInfoScreen.ktで新形式を使用