### PR TITLE
Fix URL handling for short story episodes

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import org.jsoup.Jsoup
+import org.jsoup.HttpStatusException
 import org.yaml.snakeyaml.Yaml
 import java.io.BufferedReader
 import java.io.InputStreamReader
@@ -408,7 +409,30 @@ object NovelApiUtils {
                     connection.cookie("over18", "yes")
                 }
 
-                var doc = connection.get()
+                var doc = try {
+                    connection.get()
+                } catch (e: org.jsoup.HttpStatusException) {
+                    // 404エラーかつepisodeNo == 1の場合、短編小説の可能性があるため話数なしURLを試す
+                    if (e.statusCode == 404 && episodeNo == 1 && noveltype != 2) {
+                        Log.d(TAG, "404エラーを検出。短編小説として話数なしURLを試します: $baseUrl/$ncode/")
+                        val fallbackConnection = Jsoup.connect("$baseUrl/$ncode/")
+                            .userAgent(randomUserAgent)
+                            .timeout(30000)
+                            .followRedirects(true)
+
+                        if (isR18 ||
+                            url.contains("novel18.syosetu.com") ||
+                            url.contains("noc.syosetu.com") ||
+                            url.contains("mid.syosetu.com") ||
+                            url.contains("mnlt.syosetu.com")) {
+                            fallbackConnection.cookie("over18", "yes")
+                        }
+
+                        fallbackConnection.get()
+                    } else {
+                        throw e
+                    }
+                }
 
                 // レスポンスが年齢確認ページかチェック
                 val htmlContent = doc.html()


### PR DESCRIPTION
404エラー時に話数なしURLへフォールバックする処理を追加。
noveltype情報が不正確な場合でも、短編小説を正しく取得できるようになった。

- episodeNo == 1で404エラーの場合、話数なしURLを自動的に試行
- HttpStatusExceptionのインポートを追加
- 短編小説URL形式: https://~~~~/ncode/ に対応