### PR TITLE
Fix slow performance in novel list

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -298,23 +298,6 @@ fun NovelListScreen(
     LaunchedEffect(settingsLoaded) {
         if (!settingsLoaded) return@LaunchedEffect
         repository.allNovels.collect { novelsList ->
-            novelsList.forEach { novel ->
-                if (novel.userid == null || novel.noveltype == null || novel.length == null) {
-                    scope.launch {
-                        val info = NovelApiUtils.fetchNovelInfo(novel.ncode, novel.rating == 1)
-                        if (info != null) {
-                            repository.updateNovel(
-                                novel.copy(
-                                    userid = info.userid,
-                                    noveltype = info.noveltype,
-                                    length = info.length
-                                )
-                            )
-                        }
-                    }
-                }
-            }
-
             novelList = novelsList
         }
     }


### PR DESCRIPTION
- NovelListScreenでの大量の同時API呼び出しを削除
- userid/noveltype/lengthのnullチェックによる自動補完処理を削除
- データベースから取得したデータをそのまま表示
- これにより100件の小説がある場合の100個の同時リクエストを回避