### PR TITLE
Fix ruby text overflow in horizontal layout

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -747,16 +747,17 @@ fun EnhancedHtmlRubyWebView(
             ${if (textOrientation == "Vertical") {
                 "min-height: 100vh; width: auto; overflow-x: auto; overflow-y: hidden;"
             } else {
-                "min-height: 100vh; overflow-y: auto;"
+                "min-height: 100vh; overflow-y: auto; word-wrap: break-word; overflow-wrap: break-word;"
             }}
             box-sizing: border-box;
         }
         p {
             margin: 0.5em 0;
-            ${if (textOrientation == "Vertical") "height: auto;" else ""}
+            ${if (textOrientation == "Vertical") "height: auto;" else "word-wrap: break-word; overflow-wrap: break-word;"}
         }
         ruby {
             ruby-align: center;
+            ${if (textOrientation == "Horizontal") "display: inline-block; max-width: 100%;" else ""}
         }
         rt {
             font-size: ${rubyFontSize}px;


### PR DESCRIPTION
EpisodeViewScreen.ktのWebView CSS設定を改善:
- 横書き時にword-wrap/overflow-wrapを追加してテキスト折り返しを有効化
- rubyタグにdisplay: inline-blockとmax-width: 100%を設定
- これによりルビ付きテキストが画面幅を超えて表示される問題を解決