### PR TITLE
Fix scroll position when returning from novel details

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -276,7 +276,8 @@ when (val currentScreen = navigationManager.currentScreen) {
                 onBack = { navigationManager.navigateTo(Screen.Main) },
                 onNovelClick = { ncode ->
                     navigationManager.navigateTo(Screen.EpisodeList(ncode, currentScreen))
-                }
+                },
+                navigationManager = navigationManager
             )
         }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -77,7 +77,8 @@ data class NovelWithReadInfo(
 @Composable
 fun NovelListScreen(
     onBack: () -> Unit,
-    onNovelClick: (String) -> Unit
+    onNovelClick: (String) -> Unit,
+    navigationManager: com.shunlight_library.novel_reader.navigation.NavigationManager? = null
 ) {
     val repository = NovelReaderApplication.getRepository()
     val context = androidx.compose.ui.platform.LocalContext.current
@@ -114,6 +115,24 @@ fun NovelListScreen(
     var lastReadMap by remember { mutableStateOf<Map<String, LastReadNovelEntity>>(emptyMap()) }
 
     val listState = rememberLazyListState()
+
+    // スクロール位置を復元
+    LaunchedEffect(Unit) {
+        navigationManager?.getScrollPosition("NovelList")?.let { (index, offset) ->
+            listState.scrollToItem(index, offset)
+        }
+    }
+
+    // 画面が破棄される時にスクロール位置を保存
+    DisposableEffect(Unit) {
+        onDispose {
+            navigationManager?.saveScrollPosition(
+                "NovelList",
+                listState.firstVisibleItemIndex,
+                listState.firstVisibleItemScrollOffset
+            )
+        }
+    }
 
     // 設定読み込み完了フラグ
     var settingsLoaded by remember { mutableStateOf(false) }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/navigation/NavigationManager.kt
@@ -21,6 +21,9 @@ class NavigationManager {
     val currentScreen: Screen
         get() = _currentScreen.value
 
+    /** スクロール位置を保存するMap (画面のキー → (firstVisibleItemIndex, firstVisibleItemScrollOffset)) */
+    private val scrollPositions = mutableMapOf<String, Pair<Int, Int>>()
+
     /** 新しい [screen] を表示し、現在の画面をスタックに積む */
     fun navigateTo(screen: Screen) {
         screenStack.add(_currentScreen.value)
@@ -63,6 +66,33 @@ class NavigationManager {
     fun navigateClearingBackStack(screen: Screen) {
         screenStack.clear()
         _currentScreen.value = screen
+    }
+
+    /**
+     * 指定した画面のスクロール位置を保存する
+     * @param screenKey 画面を識別するキー
+     * @param firstVisibleItemIndex 最初に表示されているアイテムのインデックス
+     * @param firstVisibleItemScrollOffset 最初に表示されているアイテムのスクロールオフセット
+     */
+    fun saveScrollPosition(screenKey: String, firstVisibleItemIndex: Int, firstVisibleItemScrollOffset: Int) {
+        scrollPositions[screenKey] = Pair(firstVisibleItemIndex, firstVisibleItemScrollOffset)
+    }
+
+    /**
+     * 指定した画面のスクロール位置を取得する
+     * @param screenKey 画面を識別するキー
+     * @return 保存されたスクロール位置（firstVisibleItemIndex, firstVisibleItemScrollOffset）、保存されていない場合はnull
+     */
+    fun getScrollPosition(screenKey: String): Pair<Int, Int>? {
+        return scrollPositions[screenKey]
+    }
+
+    /**
+     * 指定した画面のスクロール位置をクリアする
+     * @param screenKey 画面を識別するキー
+     */
+    fun clearScrollPosition(screenKey: String) {
+        scrollPositions.remove(screenKey)
     }
 }
 


### PR DESCRIPTION
小説一覧から小説目次に移動して戻るボタンで戻った時に、
スクロール位置が維持されるようにしました。

実装内容：
- NavigationManagerにスクロール位置を保存・復元する機能を追加
- NovelListScreenでNavigationManagerを使用してスクロール位置を保存・復元
- 画面遷移時にDisposableEffectでスクロール位置を保存
- 画面復帰時にLaunchedEffectでスクロール位置を復元

変更ファイル：
- NavigationManager.kt: saveScrollPosition, getScrollPosition, clearScrollPosition メソッドを追加
- NovelListScreen.kt: NavigationManagerを引数として受け取り、スクロール位置を保存・復元
- MainActivity.kt: NovelListScreenにNavigationManagerを渡す