### PR TITLE
Fix ruby text display position

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -757,7 +757,11 @@ fun EnhancedHtmlRubyWebView(
         }
         ruby {
             ruby-align: center;
-            ${if (textOrientation == "Horizontal") "display: inline-block; max-width: 100%;" else ""}
+            ${if (textOrientation == "Horizontal") {
+                "ruby-position: over; display: inline-block; max-width: 100%;"
+            } else {
+                "ruby-position: right;"
+            }}
         }
         rt {
             font-size: ${rubyFontSize}px;


### PR DESCRIPTION
横書き時にruby-position: over、縦書き時にruby-position: rightを 明示的に指定することで、ルビが正しくベーステキストの上（縦書きは右）に
表示されるようにしました。