### PR TITLE
Fix Kakuyomu work ID parsing error

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -110,7 +110,16 @@ class KakuyomuAdapter : NovelSiteAdapter {
     }
 
     override fun isValidNovelId(novelId: String): Boolean {
-        return novelId.isNotEmpty() && (novelId.toLongOrNull() != null || PseudoNcodeGenerator.isKakuyomuNcode(novelId))
+        if (novelId.isEmpty()) return false
+        if (PseudoNcodeGenerator.isKakuyomuNcode(novelId)) return true
+
+        // BigIntegerで数値かどうかを判定（Long型の範囲外も対応）
+        return try {
+            java.math.BigInteger(novelId)
+            true
+        } catch (e: NumberFormatException) {
+            false
+        }
     }
 
     /**

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/Base62Converter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/Base62Converter.kt
@@ -5,6 +5,8 @@
  */
 package com.shunlight_library.novel_reader.utils
 
+import java.math.BigInteger
+
 /**
  * Base62エンコーディングを提供するユーティリティクラス
  *
@@ -63,6 +65,63 @@ object Base62Converter {
                 throw IllegalArgumentException("Invalid Base62 character: $char")
             }
             result = result * BASE + index
+        }
+
+        return result
+    }
+
+    /**
+     * BigInteger数値をBase62文字列にエンコード
+     *
+     * Long型の範囲を超える大きな数値に対応
+     *
+     * @param number エンコードする数値（0以上）
+     * @return Base62文字列
+     * @throws IllegalArgumentException 負の数が渡された場合
+     */
+    fun encodeBigInteger(number: BigInteger): String {
+        if (number < BigInteger.ZERO) {
+            throw IllegalArgumentException("Number must be non-negative: $number")
+        }
+        if (number == BigInteger.ZERO) {
+            return "0"
+        }
+
+        var num = number
+        val result = StringBuilder()
+        val base = BigInteger.valueOf(BASE.toLong())
+
+        while (num > BigInteger.ZERO) {
+            result.append(BASE62_CHARS[(num % base).toInt()])
+            num /= base
+        }
+
+        return result.reverse().toString()
+    }
+
+    /**
+     * Base62文字列をBigInteger数値にデコード
+     *
+     * Long型の範囲を超える大きな数値に対応
+     *
+     * @param base62 デコードするBase62文字列
+     * @return 元の数値
+     * @throws IllegalArgumentException 無効な文字が含まれる場合
+     */
+    fun decodeBigInteger(base62: String): BigInteger {
+        if (base62.isEmpty()) {
+            throw IllegalArgumentException("Base62 string cannot be empty")
+        }
+
+        var result = BigInteger.ZERO
+        val base = BigInteger.valueOf(BASE.toLong())
+
+        for (char in base62) {
+            val index = BASE62_CHARS.indexOf(char)
+            if (index == -1) {
+                throw IllegalArgumentException("Invalid Base62 character: $char")
+            }
+            result = result * base + BigInteger.valueOf(index.toLong())
         }
 
         return result

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/PseudoNcodeGenerator.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/PseudoNcodeGenerator.kt
@@ -5,6 +5,8 @@
  */
 package com.shunlight_library.novel_reader.utils
 
+import java.math.BigInteger
+
 /**
  * Pseudo-Ncode生成・検証ユーティリティ
  *
@@ -29,14 +31,17 @@ object PseudoNcodeGenerator {
      * @throws IllegalArgumentException workIdが数値でない場合
      */
     fun generateKakuyomuNcode(workId: String): String {
-        val numericId = workId.toLongOrNull()
-            ?: throw IllegalArgumentException("Invalid Kakuyomu work ID (not a number): $workId")
+        val numericId = try {
+            BigInteger(workId)
+        } catch (e: NumberFormatException) {
+            throw IllegalArgumentException("Invalid Kakuyomu work ID (not a number): $workId", e)
+        }
 
-        if (numericId < 0) {
+        if (numericId < BigInteger.ZERO) {
             throw IllegalArgumentException("Invalid Kakuyomu work ID (negative): $workId")
         }
 
-        return KAKUYOMU_PREFIX + Base62Converter.encode(numericId)
+        return KAKUYOMU_PREFIX + Base62Converter.encodeBigInteger(numericId)
     }
 
     /**
@@ -58,7 +63,7 @@ object PseudoNcodeGenerator {
             throw IllegalArgumentException("Invalid Kakuyomu pseudo-ncode (empty Base62 part): $pseudoNcode")
         }
 
-        return Base62Converter.decode(base62Part).toString()
+        return Base62Converter.decodeBigInteger(base62Part).toString()
     }
 
     /**


### PR DESCRIPTION
カクヨムのwork IDがLong型の最大値（2^63-1）を超える場合に
IllegalArgumentExceptionが発生していた問題を修正。

変更内容:
- Base62Converterに BigInteger対応のエンコード/デコード関数を追加
- PseudoNcodeGeneratorでBigIntegerを使用してwork IDを処理
- KakuyomuAdapterのisValidNovelIdでBigIntegerによる検証に変更

修正前のエラー:
- work ID 16817330658027210412 が Long.MAX_VALUE を超えるため失敗
- toLongOrNull() が null を返し、例外が発生

修正後:
- 任意の大きさの数値work IDに対応
- Base62エンコーディングの可逆性を維持