### PR TITLE
Fix data retrieval from Narou API

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/SyosetuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/SyosetuAdapter.kt
@@ -139,4 +139,33 @@ class SyosetuAdapter : NovelSiteAdapter {
     fun extractNcodeWithR18FromUrl(url: String): Pair<String?, Boolean> {
         return NovelApiUtils.extractNcodeFromUrl(url)
     }
+
+    /**
+     * R18判定付きでWebサイトURLを生成
+     * @param novelId 小説のNcode
+     * @param isR18 R18作品かどうか
+     * @return WebサイトURL
+     */
+    fun generateWebUrlR18(novelId: String, isR18: Boolean): String {
+        return if (isR18) {
+            "https://novel18.syosetu.com/$novelId/"
+        } else {
+            "https://ncode.syosetu.com/$novelId/"
+        }
+    }
+
+    /**
+     * R18判定付きでエピソードURLを生成
+     * @param novelId 小説のNcode
+     * @param episodeId エピソード番号
+     * @param isR18 R18作品かどうか
+     * @return エピソードURL
+     */
+    fun generateEpisodeUrlR18(novelId: String, episodeId: String, isR18: Boolean): String {
+        return if (isR18) {
+            "https://novel18.syosetu.com/$novelId/$episodeId/"
+        } else {
+            "https://ncode.syosetu.com/$novelId/$episodeId/"
+        }
+    }
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -319,7 +319,18 @@ class NovelRepository(
                     ?: return@withContext null
 
                 // 小説情報とエピソード一覧を取得
-                val (novel, episodes) = adapter.fetchNovelWithEpisodes(novelId)
+                val (novel, episodes) = when (adapter.getSiteType()) {
+                    com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_SYOSETU -> {
+                        // 小説家になろうの場合、URLからR18判定を取得してから小説データを取得
+                        val syosetuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.SyosetuAdapter
+                        val (ncode, isR18) = syosetuAdapter.extractNcodeWithR18FromUrl(url)
+                        syosetuAdapter.fetchNovelWithEpisodesR18(novelId, isR18)
+                    }
+                    else -> {
+                        // その他のサイトは通常の取得方法
+                        adapter.fetchNovelWithEpisodes(novelId)
+                    }
+                }
 
                 // DBに保存
                 insertNovel(novel)
@@ -437,9 +448,10 @@ class NovelRepository(
 
                 when (adapter.getSiteType()) {
                     com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_SYOSETU -> {
-                        // 小説家になろうの場合、URLEntityから取得
-                        val urlEntity = getURLByNcode(ncode)
-                        urlEntity?.url ?: adapter.generateWebUrl(ncode)
+                        // 小説家になろうの場合、R18判定を使用してURL生成
+                        val syosetuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.SyosetuAdapter
+                        val isR18 = novel.rating == 1
+                        syosetuAdapter.generateWebUrlR18(ncode, isR18)
                     }
                     com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_KAKUYOMU -> {
                         // カクヨムの場合、Pseudo-NcodeからworkIdを抽出してURL生成
@@ -470,7 +482,10 @@ class NovelRepository(
 
                 when (adapter.getSiteType()) {
                     com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_SYOSETU -> {
-                        adapter.generateEpisodeUrl(ncode, episodeNo)
+                        // 小説家になろうの場合、R18判定を使用してURL生成
+                        val syosetuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.SyosetuAdapter
+                        val isR18 = novel.rating == 1
+                        syosetuAdapter.generateEpisodeUrlR18(ncode, episodeNo, isR18)
                     }
                     com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_KAKUYOMU -> {
                         val workId = com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator.extractKakuyomuWorkId(ncode)


### PR DESCRIPTION
問題:
- URLから小説を追加する際、R18サイト(novel18.syosetu.com)のURLを 指定しても、常に一般サイト(ncode.syosetu.com)のAPIにアクセスしていた
- そのため、R18作品のデータ取得が失敗していた

修正内容:
1. NovelRepository.addNovelByUrl:
   - URLからR18フラグを抽出してから小説データを取得するように修正
   - SyosetuAdapterのfetchNovelWithEpisodesR18メソッドを使用

2. SyosetuAdapter:
   - generateWebUrlR18メソッドを追加（R18判定付きURL生成）
   - generateEpisodeUrlR18メソッドを追加（R18判定付きURL生成）

3. NovelRepository (URL生成メソッド):
   - getNovelWebUrl: ratingフィールドからR18判定してURL生成
   - getEpisodeWebUrl: ratingフィールドからR18判定してURL生成

これにより、R18サイトのURLからも正しくデータを取得できるようになった