### PR TITLE
Novel site mobile viewing screen

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/WebViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/WebViewScreen.kt
@@ -102,8 +102,8 @@ fun WebViewScreen(
             builtInZoomControls = true
             displayZoomControls = false
 
-            // ユーザーエージェント設定（最新のChromeに更新）
-            userAgentString = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            // ユーザーエージェント設定（モバイル版強制）
+            userAgentString = "Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
 
             // WebViewデフォルトエンコーディング
             defaultTextEncodingName = "UTF-8"


### PR DESCRIPTION
User-AgentをデスクトップChrome（Windows）からモバイルChrome（Android）に変更し、小説サイト閲覧時に常にモバイル版サイトを表示するようにした。

変更内容:
- User-Agentを「Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36」に変更
- コメントを「モバイル版強制」に更新