### PR TITLE
Fix Episode view layout and text formatting

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -768,17 +768,19 @@ fun EnhancedHtmlRubyWebView(
             ${if (textOrientation == "Vertical") "height: auto;" else "word-wrap: break-word; overflow-wrap: break-word;"}
         }
         ruby {
+            display: ruby;
             ruby-align: center;
             ${if (textOrientation == "Horizontal") {
-                "ruby-position: over; display: inline-block; max-width: 100%;"
+                "ruby-position: over;"
             } else {
                 "ruby-position: right;"
             }}
         }
         rt {
+            display: ruby-text;
             font-size: ${rubyFontSize}px;
             text-align: center;
-            line-height: 1;
+            line-height: 1.2;
             color: $fontColor;
         }
         img {


### PR DESCRIPTION
ルビが下部に表示されて行構造が崩れていた問題を修正:
- ruby タグに display: ruby を明示的に指定
- 不要な display: inline-block と max-width: 100% を削除
- rt タグに display: ruby-text を追加
- line-height を 1.2 に調整して適切な間隔を確保