### PR TITLE
Fix novel data refresh confirmation issue

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapterFactory
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
@@ -335,7 +336,8 @@ fun EpisodeListScreen(
                         val adapter = NovelSiteAdapterFactory.getAdapter(NovelSiteAdapter.SITE_TYPE_KAKUYOMU)
                         val workId = PseudoNcodeGenerator.extractKakuyomuWorkId(ncode)
 
-                        val (updatedNovelDesc, episodes) = adapter.fetchNovelWithEpisodes(workId)
+                        // 本文なしでメタデータとエピソードリストのみを取得
+                        val (updatedNovelDesc, episodes) = (adapter as KakuyomuAdapter).fetchNovelMetadataWithEpisodeList(workId)
 
                         if (session.isCancelled()) {
                             handleCancellation()

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -111,6 +111,39 @@ class KakuyomuAdapter : NovelSiteAdapter {
         Pair(novelDesc, episodesWithBody)
     }
 
+    /**
+     * 小説のメタデータとエピソードリスト（本文なし）のみを取得する
+     *
+     * このメソッドは再取得時の確認ダイアログ前に使用され、
+     * 本文を取得せずにエピソード数などのメタデータのみを取得する。
+     *
+     * @param novelId カクヨムの作品IDまたはPseudo-Ncode
+     * @return 小説メタデータとエピソードリスト（本文は空文字列）のペア
+     */
+    suspend fun fetchNovelMetadataWithEpisodeList(novelId: String): Pair<NovelDescEntity, List<EpisodeEntity>> = withContext(Dispatchers.IO) {
+        val workId = if (PseudoNcodeGenerator.isKakuyomuNcode(novelId)) {
+            PseudoNcodeGenerator.extractKakuyomuWorkId(novelId)
+        } else {
+            novelId
+        }
+
+        applyRateLimit()
+
+        val url = generateWebUrl(workId)
+        val html = performHttpRequest(url)
+        val doc = Jsoup.parse(html)
+
+        // 小説情報を抽出
+        val novelDesc = parseNovelInfo(doc, workId)
+
+        // エピソード一覧を抽出（本文なし）
+        val episodesWithoutBody = parseEpisodeList(workId, novelDesc.ncode)
+
+        android.util.Log.d("KakuyomuAdapter", "小説メタデータとエピソードリスト取得完了（本文なし）: ${novelDesc.title}, ${episodesWithoutBody.size}話")
+
+        Pair(novelDesc, episodesWithoutBody)
+    }
+
     override suspend fun checkForUpdates(novelId: String, currentEpisodeCount: Int): Boolean = withContext(Dispatchers.IO) {
         val workId = if (PseudoNcodeGenerator.isKakuyomuNcode(novelId)) {
             PseudoNcodeGenerator.extractKakuyomuWorkId(novelId)


### PR DESCRIPTION
## 変更内容

### KakuyomuAdapter.kt
- `fetchNovelMetadataWithEpisodeList`メソッドを追加
  - 小説メタデータとエピソードリスト（本文なし）のみを取得
  - 再取得の確認ダイアログ前に使用するためのメソッド
  - 本文取得を行わず、エピソード数などのメタデータのみを取得

### EpisodeListScreen.kt
- `performRedownload`関数を修正
  - カクヨムの場合、`fetchNovelWithEpisodes`の代わりに`fetchNovelMetadataWithEpisodeList`を使用
  - 確認ダイアログを表示する前に本文を取得しないように変更
- `KakuyomuAdapter`のimportを追加

## 効果
- カクヨム小説の再取得を実施する際、確認ダイアログを表示する前に本文を全取得しなくなる
- ユーザーが「はい」を選択した場合のみ、本文を取得するように改善