### PR TITLE
Fix unresolved references and import syntax errors

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -409,7 +409,7 @@ object NovelApiUtils {
                     return@withContext if (body.isNotEmpty()) {
                         EpisodeEntity(
                             ncode = ncode,
-                            episode_no = episodeId,
+                            episode_no = episodeNoInt ?: 1,
                             body = body,
                             e_title = title,
                             update_time = currentDate,
@@ -417,7 +417,7 @@ object NovelApiUtils {
                             is_bookmark = false
                         )
                     } else {
-                        Log.e(TAG, "カクヨムエピソード本文が空です: workId=$workId, episodeId=$episodeId")
+                        Log.e(TAG, "カクヨムエピソード本文が空です: workId=$workId, episodeId=$kakuyomuEpisodeId")
                         null
                     }
                 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -9,15 +9,6 @@ import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity
 import com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity
 import com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator
-
-/**
- * カクヨムのエピソード取得結果（内部使用）
- * エピソードとマッピング情報を一緒に保持する
- */
-internal data class KakuyomuEpisodeWithMapping(
-    val episode: EpisodeEntity,
-    val kakuyomuEpisodeId: String  // カクヨムの実際のエピソードID
-)
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -29,6 +20,15 @@ import java.net.URL
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+
+/**
+ * カクヨムのエピソード取得結果（内部使用）
+ * エピソードとマッピング情報を一緒に保持する
+ */
+internal data class KakuyomuEpisodeWithMapping(
+    val episode: EpisodeEntity,
+    val kakuyomuEpisodeId: String  // カクヨムの実際のエピソードID
+)
 
 /**
  * カクヨム用のアダプター実装


### PR DESCRIPTION
- Fix NovelApiUtils.kt: Replace undefined 'episodeId' with correct variables
  - Line 412: Use 'episodeNoInt ?: 1' for episode_no field
  - Line 420: Use 'kakuyomuEpisodeId' in error log message
- Fix KakuyomuAdapter.kt: Move data class after imports to resolve syntax error
  - Move KakuyomuEpisodeWithMapping data class definition after all import statements
  - Consolidate all imports at the top of the file per Kotlin syntax rules