### PR TITLE
Fix type mismatch: use String episodeNo instead of Int

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -409,7 +409,7 @@ object NovelApiUtils {
                     return@withContext if (body.isNotEmpty()) {
                         EpisodeEntity(
                             ncode = ncode,
-                            episode_no = episodeNoInt ?: 1,
+                            episode_no = episodeNo,
                             body = body,
                             e_title = title,
                             update_time = currentDate,


### PR DESCRIPTION
- NovelApiUtils.kt:412: Change episode_no from 'episodeNoInt ?: 1' to 'episodeNo'
- EpisodeEntity.episode_no expects String, not Int
- episodeNo parameter is already a String, no conversion needed