### PR TITLE
Code Maintenance and Updates

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -167,12 +167,18 @@ object NovelApiUtils {
 
                 val inputStream = try {
                     if (useGzip) {
-                        GZIPInputStream(connection.inputStream)
+                        try {
+                            GZIPInputStream(connection.inputStream)
+                        } catch (gzipError: Exception) {
+                            // GZIP解凍に失敗した場合、非圧縮として再試行
+                            Log.w(TAG, "GZIP解凍エラー、非圧縮として再試行: ${gzipError.message}")
+                            connection.inputStream
+                        }
                     } else {
                         connection.inputStream
                     }
                 } catch (e: Exception) {
-                    Log.e(TAG, "GZIP解凍エラー: ${e.message}", e)
+                    Log.e(TAG, "InputStream取得エラー: ${e.message}", e)
                     throw e
                 }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -46,7 +46,7 @@ class KakuyomuAdapter : NovelSiteAdapter {
 
     companion object {
         private const val BASE_URL = "https://kakuyomu.jp"
-        private const val RATE_LIMIT_DELAY_MS = 100L  // 1秒（スクレイピング時の推奨間隔）
+        private const val RATE_LIMIT_DELAY_MS = 250L  // 0.25秒（スクレイピング時の推奨間隔）
         private var lastAccessTime = 0L
 
         // PC版User-Agentを使用（モバイル版では目次が省略される可能性があるため）

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -282,9 +282,9 @@ class NovelRepository(
 
         // 新しいURLEntityを作成
         val apiUrl = if (isR18) {
-            "https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5&json"
+            "https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5"
         } else {
-            "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5&json"
+            "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5"
         }
         val webUrl = if (isR18) {
             "https://novel18.syosetu.com/$ncode/"


### PR DESCRIPTION
- Change KakuyomuAdapter rate limit from 100ms to 250ms (0.25s)
- Remove &json parameter from API URLs in NovelRepository
- Implement GZIP decompression retry logic in NovelApiUtils
- Confirm AutoUpdateWorker already uses NotificationCompat.Builder correctly

Changes:
1. KakuyomuAdapter.kt:49 - RATE_LIMIT_DELAY_MS: 100L -> 250L
2. NovelRepository.kt:285-286 - Remove &json from API URLs
3. NovelApiUtils.kt:168-183 - Add GZIP error fallback to uncompressed stream