### PR TITLE
Change novel list sort site selector to dropdown

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -641,26 +641,32 @@ fun NovelListScreen(
                     Text("サイトフィルター", style = MaterialTheme.typography.bodyLarge, fontWeight = FontWeight.Bold)
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    SiteFilter.values().forEach { filter ->
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    tempFilterSettings = tempFilterSettings.copy(siteFilter = filter)
-                                }
-                                .padding(vertical = 8.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                    var siteFilterExpanded by remember { mutableStateOf(false) }
+                    Box {
+                        OutlinedButton(
+                            onClick = { siteFilterExpanded = true },
+                            modifier = Modifier.fillMaxWidth()
                         ) {
-                            RadioButton(
-                                selected = tempFilterSettings.siteFilter == filter,
-                                onClick = {
-                                    tempFilterSettings = tempFilterSettings.copy(siteFilter = filter)
-                                }
-                            )
                             Text(
-                                text = filter.displayName,
-                                modifier = Modifier.padding(start = 8.dp)
+                                text = tempFilterSettings.siteFilter.displayName,
+                                modifier = Modifier.weight(1f)
                             )
+                            Icon(Icons.Default.ArrowDropDown, contentDescription = "サイト選択")
+                        }
+
+                        DropdownMenu(
+                            expanded = siteFilterExpanded,
+                            onDismissRequest = { siteFilterExpanded = false }
+                        ) {
+                            SiteFilter.values().forEach { filter ->
+                                DropdownMenuItem(
+                                    text = { Text(filter.displayName) },
+                                    onClick = {
+                                        tempFilterSettings = tempFilterSettings.copy(siteFilter = filter)
+                                        siteFilterExpanded = false
+                                    }
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
小説一覧画面のフィルター設定ダイアログにて、サイトフィルター選択をRadioButtonからDropdownMenuに変更しました。

変更内容:
- RadioButtonによる縦並び選択からOutlinedButton+DropdownMenuのプルダウン形式に変更
- UIがよりコンパクトになり、スペース効率が向上
- ユーザビリティの改善