### PR TITLE
Add download sort feature to novel list

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -38,7 +38,7 @@ enum class SortField(val displayName: String) {
     TOTAL_EP("総話数"),
     UNREAD_COUNT("未読数"),
     LENGTH("文字数"),
-    LAST_UPDATE_DATE("ダウンロード日"),
+    REGISTERED_AT("登録日"),
     UPDATED_AT("最終更新日")
 }
 
@@ -284,10 +284,10 @@ fun NovelListScreen(
                     filtered.sortedByDescending { it.novel.length ?: 0 }
                 }
 
-                SortField.LAST_UPDATE_DATE -> if (sortDirection == SortDirection.ASCENDING) {
-                    filtered.sortedBy { it.novel.last_update_date }
+                SortField.REGISTERED_AT -> if (sortDirection == SortDirection.ASCENDING) {
+                    filtered.sortedBy { it.novel.registered_at }
                 } else {
-                    filtered.sortedByDescending { it.novel.last_update_date }
+                    filtered.sortedByDescending { it.novel.registered_at }
                 }
 
                 SortField.UPDATED_AT -> if (sortDirection == SortDirection.ASCENDING) {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -38,7 +38,7 @@ data class CustomFontInfo(
 
 // NovelListFilter設定用のデータクラス
 data class NovelListFilterSettings(
-    val sortField: String = "LAST_UPDATE_DATE",
+    val sortField: String = "UPDATED_AT",
     val sortDirection: String = "DESCENDING",
     val minRating: Int = 0,
     val maxRating: Int = 5,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -322,12 +322,15 @@ object NovelApiUtils {
                         val length = (novelData["length"] as? Int)
                         val keyword = novelData["keyword"] as? String ?: ""
 
+                        // APIから取得した小説の最終更新日時（サイト上の更新日時）
+                        val updatedAt = novelData["updated_at"] as? String ?: ""
+
                         // キーワードから最初のタグをメインタグ、残りをサブタグとして扱う
                         val tags = keyword.split(" ")
                         val mainTag = if (tags.isNotEmpty()) tags[0] else ""
                         val subTag = if (tags.size > 1) tags.subList(1, tags.size).joinToString(" ") else ""
 
-                        // 現在の日時を取得
+                        // 現在の日時を取得（データベース登録日時として使用）
                         val currentDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
 
                         // レーティング（R18なら1、それ以外なら2）
@@ -341,13 +344,14 @@ object NovelApiUtils {
                             main_tag = mainTag,
                             sub_tag = subTag,
                             rating = rating,
-                            last_update_date = currentDate,
+                            last_update_date = updatedAt,  // サイト上の最終更新日
                             total_ep = 0, // 初期値は0、後で更新処理で正確な値が設定される
                             general_all_no = generalAllNo,
                             userid = userid,
                             noveltype = noveltype,
                             length = length,
-                            updated_at = currentDate
+                            updated_at = updatedAt,  // サイト上の最終更新日時
+                            registered_at = currentDate  // データベース登録日時
                         )
                     } else {
                         null

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -576,15 +576,16 @@ class KakuyomuAdapter : NovelSiteAdapter {
             main_tag = mainTag,
             sub_tag = subTag,
             rating = 2,  // カクヨムは一般のみ
-            last_update_date = lastUpdateDate,
+            last_update_date = lastUpdateDate,  // サイト上の最終更新日
             total_ep = totalEp,
             general_all_no = 0,  // カクヨムにはこの情報がない
             userid = null,  // HTMLから抽出困難
             noveltype = if (totalEp == 1) 2 else 1,  // 1話のみなら短編、それ以外は連載
             length = null,  // HTMLから抽出困難
-            updated_at = getCurrentDateTime(),
+            updated_at = lastUpdateDate,  // サイト上の最終更新日時
             is_favorite = false,
-            site_type = NovelSiteAdapter.SITE_TYPE_KAKUYOMU
+            site_type = NovelSiteAdapter.SITE_TYPE_KAKUYOMU,
+            registered_at = getCurrentDateTime()  // データベース登録日時
         )
     }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
@@ -160,6 +160,20 @@ val MIGRATION_9_10 = object : Migration(9, 10) {
 }
 
 /**
+ * v10→v11のマイグレーション: データベース登録日時を追加
+ */
+val MIGRATION_10_11 = object : Migration(10, 11) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        // registered_atカラムを追加（既存データにはlast_update_dateの値をコピー）
+        database.execSQL("ALTER TABLE novels_descs ADD COLUMN registered_at TEXT NOT NULL DEFAULT ''")
+        // 既存データのregistered_atをlast_update_dateと同じ値に設定
+        database.execSQL("UPDATE novels_descs SET registered_at = last_update_date")
+        // インデックスを作成
+        database.execSQL("CREATE INDEX IF NOT EXISTS idx_novels_registered ON novels_descs (registered_at)")
+    }
+}
+
+/**
  * アプリ全体で使用するRoomデータベース定義
  */
 @Database(
@@ -172,7 +186,7 @@ val MIGRATION_9_10 = object : Migration(9, 10) {
         ImageCacheEntity::class,
         EpisodeMappingEntity::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 abstract class NovelDatabase : RoomDatabase() {
@@ -207,7 +221,8 @@ abstract class NovelDatabase : RoomDatabase() {
                         MIGRATION_6_7,
                         MIGRATION_7_8,
                         MIGRATION_8_9,
-                        MIGRATION_9_10
+                        MIGRATION_9_10,
+                        MIGRATION_10_11
                     )
                     .build()
                 INSTANCE = instance

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/NovelDescEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/NovelDescEntity.kt
@@ -17,7 +17,8 @@ import androidx.room.Index
         Index(value = ["is_favorite"], name = "idx_novels_favorite"),
         Index(value = ["length"], name = "idx_novels_length"),
         Index(value = ["noveltype"], name = "idx_novels_type"),
-        Index(value = ["site_type"], name = "idx_novels_site")
+        Index(value = ["site_type"], name = "idx_novels_site"),
+        Index(value = ["registered_at"], name = "idx_novels_registered")
     ]
 )
 /**
@@ -30,15 +31,16 @@ import androidx.room.Index
  * @property main_tag メインタグ
  * @property sub_tag サブタグ
  * @property rating レーティング種別 (1=R18, 2=一般)
- * @property last_update_date 最終更新日
+ * @property last_update_date 小説の最終更新日（サイト上の更新日）
  * @property total_ep エピソード総数
  * @property general_all_no 評価ポイント総数
  * @property userid 作者ID
  * @property noveltype 作品種別 (1=連載, 2=短編)
  * @property length 文字数
- * @property updated_at メタデータ更新日時
+ * @property updated_at 小説メタデータの最終更新日時（サイト上の更新日時）
  * @property is_favorite お気に入り登録フラグ
  * @property site_type サイト種別 (1=小説家になろう, 2=カクヨム)
+ * @property registered_at データベースへの登録日時（ダウンロード日時）
  */
 data class NovelDescEntity(
     val ncode: String,
@@ -56,7 +58,8 @@ data class NovelDescEntity(
     val length: Int? = null,
     val updated_at: String,
     val is_favorite: Boolean = false,
-    val site_type: Int = 1  // 1=小説家になろう, 2=カクヨム
+    val site_type: Int = 1,  // 1=小説家になろう, 2=カクヨム
+    val registered_at: String  // データベース登録日時
 )
 
 //https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua&ncode={ncode}&gzip=5&json


### PR DESCRIPTION
- NovelDescEntity: Add registered_at field to track DB registration time
- Database: Add migration v10→v11 to add registered_at column with index
- NovelApiUtils & KakuyomuAdapter: Set registered_at to current time, use API values for last_update_date and updated_at
- NovelListScreen: Change sort field from LAST_UPDATE_DATE to REGISTERED_AT (display as "登録日")
- SettingsStore: Update default sort field to match new field structure

This separates the concept of "registration date" (when added to DB) from "last update date" (when the novel was last updated on the site).