### PR TITLE
Fix deprecated icons and missing parameters

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Sort
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -767,7 +768,7 @@ fun NovelListScreen(
 
                         // 並び替えボタン
                         IconButton(onClick = { showSortDialog = true }) {
-                            Icon(Icons.Default.Sort, contentDescription = "並び替え")
+                            Icon(Icons.AutoMirrored.Filled.Sort, contentDescription = "並び替え")
                         }
 
                         // フィルターボタン

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncManager.kt
@@ -202,6 +202,7 @@ class DatabaseSyncManager(private val context: Context) {
             val columnNoveltype = getColumnIndexOrDefault(cursor, "noveltype")
             val columnLength = getColumnIndexOrDefault(cursor, "length")
             val columnUpdatedAt = getColumnIndexOrDefault(cursor, "updated_at")
+            val columnRegisteredAt = getColumnIndexOrDefault(cursor, "registered_at")
             val urlEntities = mutableListOf<URLEntity>() // URLEntityリスト追加
             val batchSize = 50
             val novels = mutableListOf<NovelDescEntity>()
@@ -222,7 +223,8 @@ class DatabaseSyncManager(private val context: Context) {
                     userid = columnUserid?.let { cursor.getString(it) }?.takeIf { it.isNotEmpty() },
                     noveltype = columnNoveltype?.let { cursor.getInt(it) },
                     length = columnLength?.let { cursor.getInt(it) },
-                    updated_at = columnUpdatedAt?.let { cursor.getString(it) } ?: getCurrentDateString()
+                    updated_at = columnUpdatedAt?.let { cursor.getString(it) } ?: getCurrentDateString(),
+                    registered_at = columnRegisteredAt?.let { cursor.getString(it) } ?: getCurrentDateString()
                 )
 
                 novels.add(novel)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/ImprovedDatabaseSyncManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/ImprovedDatabaseSyncManager.kt
@@ -320,6 +320,7 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
             val columnNoveltype = getColumnIndexSafely(cursor, "noveltype")
             val columnLength = getColumnIndexSafely(cursor, "length")
             val columnUpdatedAt = getColumnIndexSafely(cursor, "updated_at")
+            val columnRegisteredAt = getColumnIndexSafely(cursor, "registered_at")
 
             val batchSize = 50
             val novels = mutableListOf<NovelDescEntity>()
@@ -345,6 +346,8 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
                     noveltype = if (columnNoveltype != null && !cursor.isNull(columnNoveltype)) noveltype else null,
                     length = if (columnLength != null && !cursor.isNull(columnLength)) length else null,
                     updated_at = getStringSafely(cursor, columnUpdatedAt,
+                        DatabaseSyncUtils.getCurrentDateTimeString()),
+                    registered_at = getStringSafely(cursor, columnRegisteredAt,
                         DatabaseSyncUtils.getCurrentDateTimeString())
                 )
 


### PR DESCRIPTION
Changes:
- Replace deprecated Icons.Default.Sort with Icons.AutoMirrored.Filled.Sort in NovelListScreen.kt
- Add registered_at parameter to NovelDescEntity creation in DatabaseSyncManager.kt
- Add registered_at parameter to NovelDescEntity creation in ImprovedDatabaseSyncManager.kt

These fixes resolve the compilation errors where the registered_at field was required but not provided when creating NovelDescEntity instances during database synchronization.