### PR TITLE
Fix unresolved reference awaitPointerEventScope

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.drag
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.input.pointer.awaitPointerEventScope
 import androidx.compose.ui.text.style.TextOverflow
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.NovelDescEntity


### PR DESCRIPTION
Remove incorrect import for awaitPointerEventScope which is a DSL function available within pointerInput scope and cannot be imported separately.