### PR TITLE
Fix update processing queue issues

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -314,7 +314,13 @@ fun UpdateInfoScreen(
                                                             }
                                                         }
 
+                                                        var hasNewEpisodes = false
+                                                        var hasRevisedEpisodes = false
+                                                        var revisedEpisodeCount = 0
+
+                                                        // 新規エピソードのチェック
                                                         if (info.generalAllNo > novel.general_all_no) {
+                                                            hasNewEpisodes = true
                                                             val updatedNovel = novel.copy(
                                                                 general_all_no = info.generalAllNo,
                                                                 updated_at = info.updatedAt
@@ -329,8 +335,6 @@ fun UpdateInfoScreen(
                                                             )
                                                             repository.insertUpdateQueue(updateQueue)
 
-                                                            workCount++
-
                                                             if (novel.general_all_no == 0) {
                                                                 // 新着作品：全話数を加算
                                                                 episodeCount += info.generalAllNo
@@ -338,7 +342,54 @@ fun UpdateInfoScreen(
                                                                 // 更新作品：新しく追加された話数を加算
                                                                 episodeCount += (info.generalAllNo - novel.general_all_no)
                                                             }
+                                                        }
 
+                                                        // 改稿チェック（短編を除く）
+                                                        if (novel.noveltype != 2) {
+                                                            try {
+                                                                val revisionInfos = NovelApiUtils.fetchEpisodeRevisionsFromToc(
+                                                                    ncode = novel.ncode,
+                                                                    isR18 = novel.rating == 1,
+                                                                    noveltype = novel.noveltype
+                                                                )
+
+                                                                if (revisionInfos.isNotEmpty()) {
+                                                                    val existingEpisodes = repository.getEpisodesByNcode(novel.ncode).first()
+                                                                    val episodeMap = existingEpisodes.associateBy { it.episode_no.toIntOrNull() ?: 0 }
+
+                                                                    for (revisionInfo in revisionInfos) {
+                                                                        val existingEpisode = episodeMap[revisionInfo.episodeNo]
+                                                                        if (existingEpisode != null && revisionInfo.updateTime > existingEpisode.update_time) {
+                                                                            // エピソードを再取得
+                                                                            val updatedEpisode = NovelApiUtils.fetchEpisodeWithRetry(
+                                                                                ncode = novel.ncode,
+                                                                                episodeNo = revisionInfo.episodeNo.toString(),
+                                                                                isR18 = novel.rating == 1,
+                                                                                noveltype = novel.noveltype
+                                                                            )
+
+                                                                            if (updatedEpisode != null) {
+                                                                                val episodeWithRevisionTime = updatedEpisode.copy(
+                                                                                    update_time = revisionInfo.updateTime
+                                                                                )
+                                                                                repository.insertEpisode(episodeWithRevisionTime)
+                                                                                hasRevisedEpisodes = true
+                                                                                revisedEpisodeCount++
+                                                                                Log.d("UpdateCheck", "改稿を検出: ${novel.title} 第${revisionInfo.episodeNo}話 (${revisionInfo.updateTime})")
+                                                                            }
+
+                                                                            delay(200) // サーバー負荷軽減
+                                                                        }
+                                                                    }
+                                                                }
+                                                            } catch (e: Exception) {
+                                                                Log.e("UpdateCheck", "改稿チェックエラー: ${novel.ncode}", e)
+                                                            }
+                                                        }
+
+                                                        // カウント更新
+                                                        if (hasNewEpisodes || hasRevisedEpisodes) {
+                                                            workCount++
                                                             return@async true
                                                         }
                                                     }
@@ -516,6 +567,13 @@ fun UpdateInfoScreen(
                                                     // total_ep+1からgeneral_all_noまでのリストを作成
                                                     val startEpisode = novel.total_ep + 1
                                                     val endEpisode = queueItem.general_all_no
+
+                                                    // 既に更新済みの場合はキューから削除してスキップ
+                                                    if (startEpisode > endEpisode) {
+                                                        repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                                                        Log.d("UpdateInfo", "小説「${novel.title}」は既に更新済みのためキューから削除しました")
+                                                        continue
+                                                    }
 
                                                     if (startEpisode <= endEpisode) {
                                                         syncMessage = "「${novel.title}」のエピソードを更新中..."

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/UpdateQueueEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/UpdateQueueEntity.kt
@@ -17,8 +17,8 @@ import androidx.room.Index
  * 更新キューの 1 行を表す。
  *
  * @property ncode 小説の N コード
- * @property total_ep チェック時点のエピソード総数
- * @property general_all_no チェック時点の評価ポイント総数
+ * @property total_ep 更新確認時点で取得済みのエピソード数（novel.total_ep）
+ * @property general_all_no APIから取得した最新のエピソード総数（novel.general_all_no）
  * @property update_time 更新検出日時
  */
 data class UpdateQueueEntity(


### PR DESCRIPTION
更新キュー処理の修正と改稿チェックサポートを追加

主な変更点:
1. UpdateInfoScreenの更新確認処理に改稿チェックのロジックを追加
   - 小説家になろうの連載小説について、目次から改稿情報を取得
   - 改稿されたエピソードを自動的に再取得して更新
   - UpdateService.ktやUpdateCheckWorker.ktと同等の改稿検出機能を実装

2. 一括更新処理で既に更新済みのキューアイテムを適切に処理
   - 既に更新済み（total_ep >= general_all_no）のアイテムを自動的に検出
   - キューから削除してスキップすることで、無駄な処理を回避
   - ログ出力で処理状況を明確化

3. UpdateQueueEntityのドキュメントを修正
   - total_epとgeneral_all_noの意味を正確に記述
   - 誤解を招く「評価ポイント総数」から「最新のエピソード総数」に修正

これらの変更により、以下の問題が解決されます:
- キューに追加されているのに更新されない問題
- 改稿（改訂）が手動更新確認で検出されない問題
- 既に更新済みのアイテムがキューに残り続ける問題