### PR TITLE
Fix Kakuyomu novel deletion

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 135
+        versionCode = 136
         versionName = "1.5.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -196,7 +196,7 @@ class NovelRepository(
             throw IllegalStateException("進行中の更新を停止できませんでした: ${novel.ncode}")
         }
         withContext(Dispatchers.IO) {
-            episodeDao.deleteEpisodesByNcode(novel.ncode)
+            deleteEpisodesByNcode(novel.ncode)
             lastReadNovelDao.getLastReadByNcode(novel.ncode)?.let {
                 lastReadNovelDao.deleteLastRead(it)
             }


### PR DESCRIPTION
カクヨム小説の削除時にエピソードマッピング情報が削除されない問題を修正。
deleteNovelWithRelations()でDAOを直接呼び出すのではなく、
Repositoryのメソッドを使用することで、エピソードとマッピングの
両方が確実に削除されるようにした。

- NovelRepository.kt:199: episodeDao.deleteEpisodesByNcode() → deleteEpisodesByNcode()
- versionCode: 135 → 136