### PR TITLE
Increment version name per task

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,7 +112,7 @@ Use `SettingsStore` for persistent configuration with DataStore.
 4. Use NavigationManager for navigation to maintain proper back stack
 5. Handle R18 content appropriately with dialog-based site selection
 6. Maintain reading progress and bookmark functionality in EpisodeViewScreen
-7. **Version Management**: Always increment `versionCode` by +1 when making any code changes in `Novel_reader/app/build.gradle.kts`
+7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 1.5.4 → 1.5.5) when making any code changes in `Novel_reader/app/build.gradle.kts`
 
 #### Back Navigation Implementation
 **必須**: Android標準のナビゲーションバーのバックハンドラーを使用する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ Use `SettingsStore` for persistent configuration with DataStore.
 4. Use NavigationManager for navigation to maintain proper back stack
 5. Handle R18 content appropriately with dialog-based site selection
 6. Maintain reading progress and bookmark functionality in EpisodeViewScreen
-7. **Version Management**: Always increment `versionCode` by +1 when making any code changes in `Novel_reader/app/build.gradle.kts`
+7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 1.5.4 → 1.5.5) when making any code changes in `Novel_reader/app/build.gradle.kts`
 
 #### Back Navigation Implementation
 **必須**: Android標準のナビゲーションバーのバックハンドラーを使用する

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 136
-        versionName = "1.5.4"
+        versionCode = 137
+        versionName = "1.5.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
- Updated version management rule to increment both versionCode and versionName
- versionName patch version should be incremented (e.g., 1.5.4 → 1.5.5) for each task
- Applied the new rule: versionCode 136 → 137, versionName 1.5.4 → 1.5.5
- Updated both CLAUDE.md and AGENTS.md with the new rule