### PR TITLE
Fix API call on app startup

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 137
-        versionName = "1.5."
+        versionCode = 138
+        versionName = "1.5.138"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -52,6 +52,7 @@ import com.shunlight_library.novel_reader.metadata.MetadataUpdateResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.first
 
 class MainActivity : ComponentActivity() {
     private lateinit var navigationManager: NavigationManager
@@ -449,6 +450,10 @@ fun MainScreen(
     var unreadNotificationCount by remember { mutableStateOf(0) }
     var showNotificationDialog by remember { mutableStateOf(false) }
 
+    // 自動更新バックログ確認ダイアログの状態
+    var showAutoUpdateBacklogDialog by remember { mutableStateOf(false) }
+    val autoUpdateScheduler = remember { com.shunlight_library.novel_reader.worker.AutoUpdateScheduler(context) }
+
     // メタデータ補完ダイアログ用の状態
     var showMetadataConfirm by remember { mutableStateOf(false) }
     var showMetadataProgressDialog by remember { mutableStateOf(false) }
@@ -506,6 +511,11 @@ fun MainScreen(
         // 更新情報も取得
         val (workCount, episodeCount) = repository.getUpdateCountsWithEpisodes()
         updateInfoText = "${workCount}作品${episodeCount}話"
+
+        // 自動更新のバックログをチェック
+        if (autoUpdateScheduler.hasPendingWork()) {
+            showAutoUpdateBacklogDialog = true
+        }
     }
 
     // R18コンテンツ選択ダイアログ
@@ -553,6 +563,68 @@ fun MainScreen(
             dismissButton = {
                 TextButton(onClick = { showR18Dialog = false }) {
                     Text("キャンセル")
+                }
+            }
+        )
+    }
+
+    // 自動更新バックログ確認ダイアログ
+    if (showAutoUpdateBacklogDialog) {
+        AlertDialog(
+            onDismissRequest = { showAutoUpdateBacklogDialog = false },
+            title = { Text("自動更新の確認") },
+            text = {
+                Column {
+                    Text("実行待ちの自動更新があります。")
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        "これは以下のいずれかの理由で発生します：",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                    Text("• 長時間アプリを使用していなかった", style = MaterialTheme.typography.bodySmall)
+                    Text("• 実行予定時刻を過ぎている", style = MaterialTheme.typography.bodySmall)
+                    Text("• 設定を変更した直後", style = MaterialTheme.typography.bodySmall)
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text("今すぐ実行しますか？それともスキップしますか？")
+                }
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showAutoUpdateBacklogDialog = false
+                        scope.launch {
+                            // 手動で更新を実行
+                            autoUpdateScheduler.runManualUpdate()
+                            android.widget.Toast.makeText(
+                                context,
+                                "自動更新を開始しました",
+                                android.widget.Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                ) {
+                    Text("今すぐ実行")
+                }
+            },
+            dismissButton = {
+                TextButton(
+                    onClick = {
+                        showAutoUpdateBacklogDialog = false
+                        scope.launch {
+                            // バックログをリセット
+                            val settingsStore = SettingsStore(context)
+                            val enabled = settingsStore.autoUpdateEnabled.first()
+                            val time = settingsStore.autoUpdateTime.first()
+                            autoUpdateScheduler.resetSchedule(enabled, time)
+                            android.widget.Toast.makeText(
+                                context,
+                                "自動更新をスキップしました",
+                                android.widget.Toast.LENGTH_SHORT
+                            ).show()
+                        }
+                    }
+                ) {
+                    Text("スキップ")
                 }
             }
         )

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
@@ -523,8 +523,8 @@ fun SettingsScreenUpdated(
                                     settingsStore.clearImageSaveLocation()
                                 }
 
-                                // 自動更新スケジュールを設定
-                                autoUpdateScheduler.scheduleAutoUpdate(autoUpdateEnabled, autoUpdateTime)
+                                // 自動更新スケジュールをリセット（バックログをクリアして再スケジュール）
+                                autoUpdateScheduler.resetSchedule(autoUpdateEnabled, autoUpdateTime)
 
                                 // 保存したことをユーザーに通知
                                 Toast.makeText(context, "設定を保存しました", Toast.LENGTH_SHORT).show()

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
@@ -9,6 +9,8 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.work.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
 import java.util.Calendar
 
@@ -91,6 +93,34 @@ class AutoUpdateScheduler(private val context: Context) {
      */
     fun getWorkStatus(): LiveData<List<WorkInfo>> {
         return workManager.getWorkInfosForUniqueWorkLiveData(WORK_NAME)
+    }
+
+    /**
+     * バックログや実行待ちのワークがあるかチェック
+     * @return ワークが実行待ち、または実行中の場合はtrue
+     */
+    suspend fun hasPendingWork(): Boolean {
+        val workInfos = workManager.getWorkInfosForUniqueWork(WORK_NAME).await()
+        return workInfos.any { workInfo ->
+            workInfo.state == WorkInfo.State.ENQUEUED ||
+            workInfo.state == WorkInfo.State.RUNNING ||
+            workInfo.state == WorkInfo.State.BLOCKED
+        }
+    }
+
+    /**
+     * スケジュールをリセット（バックログをクリアして再スケジュール）
+     * @param enabled 自動更新の有効/無効
+     * @param timeString 時刻文字列 (例: "03:00")
+     */
+    fun resetSchedule(enabled: Boolean, timeString: String) {
+        // 既存のワークをキャンセル
+        cancelAutoUpdate()
+
+        // 再スケジュール
+        scheduleAutoUpdate(enabled, timeString)
+
+        Log.d(TAG, "スケジュールをリセットしました")
     }
 
     /**


### PR DESCRIPTION
長時間未使用やバックログがある場合に、自動更新を即座実行せず、
ユーザーに確認ダイアログを表示して選択させるように改善。

主な変更:
- AutoUpdateScheduler: バックログチェック機能と resetSchedule() メソッドを追加
- MainActivity: 起動時にバックログをチェックし、確認ダイアログを表示
- SettingsScreen: 設定変更時に resetSchedule() を使用してバックログをクリア
- build.gradle.kts: バージョンを 1.5.138 (versionCode 138) に更新

これにより、以下の状況で自動実行を防ぎ、ユーザーに選択肢を提供:
- 長時間アプリを使用していなかった
- 実行予定時刻を過ぎている
- 設定を変更した直後

ユーザーは「今すぐ実行」または「スキップ」を選択可能。