### PR TITLE
Fix unresolved reference in AutoUpdateScheduler

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.work.*
+import androidx.work.await
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit


### PR DESCRIPTION
Add missing import for androidx.work.await extension function to resolve unresolved reference errors in hasPendingWork() method.