### PR TITLE
Add universal commit message guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,7 @@ Use `SettingsStore` for persistent configuration with DataStore.
 5. Handle R18 content appropriately with dialog-based site selection
 6. Maintain reading progress and bookmark functionality in EpisodeViewScreen
 7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 1.5.4 → 1.5.5) when making any code changes in `Novel_reader/app/build.gradle.kts`
+8. **Commit Messages**: Always write commit messages in Japanese
 
 #### Back Navigation Implementation
 **必須**: Android標準のナビゲーションバーのバックハンドラーを使用する

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Use `SettingsStore` for persistent configuration with DataStore.
 5. Handle R18 content appropriately with dialog-based site selection
 6. Maintain reading progress and bookmark functionality in EpisodeViewScreen
 7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 1.5.4 → 1.5.5) when making any code changes in `Novel_reader/app/build.gradle.kts`
+8. **Commit Messages**: Always write commit messages in Japanese
 
 #### Back Navigation Implementation
 **必須**: Android標準のナビゲーションバーのバックハンドラーを使用する


### PR DESCRIPTION
Development Guidelinesセクションに新しいルール8を追加：
- すべてのコミットメッセージは日本語で記述する

この変更により、今後の開発でコミットメッセージの一貫性が向上します。