### PR TITLE
Review all update and fetch code flows

### DIFF
--- a/Novel_reader/app/src/main/AndroidManifest.xml
+++ b/Novel_reader/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
 
         <!-- 通知アクション用のBroadcastReceiver -->
         <receiver
-                android:name=".receiver.DownloadActionReceiver"
+                android:name=".receiver.DownloadAllReceiver"
                 android:exported="false">
             <intent-filter>
                 <action android:name="com.shunlight_library.novel_reader.ACTION_DOWNLOAD_ALL" />

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -47,9 +47,10 @@ import android.content.Intent
 import com.shunlight_library.novel_reader.service.UpdateService
 
 enum class UpdateType {
-    UPDATE,      // 更新（新しいエピソードのみチェック）
-    REDOWNLOAD,  // 再取得（すべて削除して再取得）
-    FIX_ERRORS   // エラー修正（エラーや欠番のあるエピソードのみ修正）
+    UPDATE,         // 更新（新しいエピソードのみチェック）
+    REDOWNLOAD,     // 再取得（すべて削除して再取得）
+    FIX_ERRORS,     // エラー修正（エラーや欠番のあるエピソードのみ修正）
+    CHECK_REVISION  // 改稿チェック（既存エピソードの改稿を確認）
 }
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -158,6 +159,39 @@ fun EpisodeListScreen(
         // ダイアログを閉じて通知を表示
         showUpdateDialog = false
         Toast.makeText(context, "バックグラウンドで更新処理を開始しました", Toast.LENGTH_SHORT).show()
+    }
+
+    // 「改稿チェック」実行関数（UpdateService経由でバックグラウンド実行）
+    fun performCheckRevision() {
+        val targetNovel = novel
+        if (targetNovel == null) {
+            Toast.makeText(context, "小説情報が読み込まれていません", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // カクヨムは非対応
+        if (targetNovel.site_type == NovelSiteAdapter.SITE_TYPE_KAKUYOMU) {
+            Toast.makeText(context, "カクヨムは改稿チェックに対応していません", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // 短編も非対応
+        if (targetNovel.noveltype == 2) {
+            Toast.makeText(context, "短編小説は改稿チェックに対応していません", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // UpdateServiceを起動して改稿チェックを実行
+        val intent = Intent(context, UpdateService::class.java).apply {
+            action = UpdateService.ACTION_START_UPDATE
+            putExtra(UpdateService.EXTRA_NCODE, targetNovel.ncode)
+            putExtra(UpdateService.EXTRA_UPDATE_TYPE, UpdateService.UPDATE_TYPE_CHECK_REVISION)
+        }
+        context.startService(intent)
+
+        // ダイアログを閉じて通知を表示
+        showUpdateDialog = false
+        Toast.makeText(context, "バックグラウンドで改稿チェックを開始しました", Toast.LENGTH_SHORT).show()
     }
 
     // 旧実装（UI処理版、参考用にコメントアウト）
@@ -1146,6 +1180,31 @@ fun EpisodeListScreen(
                                 )
                             }
                         }
+
+                        // 改稿チェック
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .selectable(
+                                    selected = selectedUpdateType == UpdateType.CHECK_REVISION,
+                                    onClick = { selectedUpdateType = UpdateType.CHECK_REVISION }
+                                )
+                                .padding(vertical = 8.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            RadioButton(
+                                selected = selectedUpdateType == UpdateType.CHECK_REVISION,
+                                onClick = { selectedUpdateType = UpdateType.CHECK_REVISION }
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Column {
+                                Text("改稿チェック", fontWeight = FontWeight.Bold)
+                                Text(
+                                    "既存エピソードの改稿を確認して再取得します（小説家になろうのみ）",
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
+                        }
                     }
                 }
             },
@@ -1157,6 +1216,7 @@ fun EpisodeListScreen(
                             UpdateType.UPDATE -> performUpdate()
                             UpdateType.REDOWNLOAD -> performRedownload()
                             UpdateType.FIX_ERRORS -> performErrorFix()
+                            UpdateType.CHECK_REVISION -> performCheckRevision()
                         }
                     },
                     enabled = !isUpdating
@@ -1345,51 +1405,6 @@ fun EpisodeListScreen(
                             expanded = isMenuExpanded,
                             onDismissRequest = { isMenuExpanded = false }
                         ) {
-                            DropdownMenuItem(
-                                text = { Text("改稿チェック") },
-                                leadingIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
-                                onClick = {
-                                    isMenuExpanded = false
-                                    // 改稿チェックを実行
-                                    scope.launch {
-                                        novel?.let { targetNovel ->
-                                            // カクヨムまたは短編小説の場合はスキップ
-                                            if (targetNovel.site_type == NovelSiteAdapter.SITE_TYPE_KAKUYOMU) {
-                                                Toast.makeText(
-                                                    context,
-                                                    "カクヨムは改稿チェックに対応していません",
-                                                    Toast.LENGTH_SHORT
-                                                ).show()
-                                                return@launch
-                                            }
-
-                                            if (targetNovel.noveltype == 2) {
-                                                Toast.makeText(
-                                                    context,
-                                                    "短編小説は改稿チェックに対応していません",
-                                                    Toast.LENGTH_SHORT
-                                                ).show()
-                                                return@launch
-                                            }
-
-                                            // UpdateService を起動して改稿チェックを実行
-                                            val intent = Intent(context, UpdateService::class.java).apply {
-                                                action = UpdateService.ACTION_START_UPDATE
-                                                putExtra(UpdateService.EXTRA_NCODE, targetNovel.ncode)
-                                                putExtra(UpdateService.EXTRA_UPDATE_TYPE, UpdateService.UPDATE_TYPE_CHECK_REVISION)
-                                            }
-                                            context.startService(intent)
-
-                                            Toast.makeText(
-                                                context,
-                                                "改稿チェックを開始しました",
-                                                Toast.LENGTH_SHORT
-                                            ).show()
-                                        }
-                                    }
-                                },
-                                enabled = novel != null && !isUpdating
-                            )
                             DropdownMenuItem(
                                 text = { Text("小説を削除") },
                                 leadingIcon = { Icon(Icons.Default.Delete, contentDescription = null) },

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -143,15 +143,22 @@ class KakuyomuAdapter : NovelSiteAdapter {
     }
 
     /**
-     * 小説情報とエピソードをマッピング情報付きで取得
+     * 小説情報とエピソードをマッピング情報付きで取得（1話ずつ保存）
      *
      * このメソッドは再取得・更新処理で使用され、エピソードマッピング情報を
      * 確実に保存できるようにする。
+     * メモリリーク防止のため、1話取得→保存→次の話、という方式で処理する。
      *
      * @param novelId カクヨムの作品IDまたはPseudo-Ncode
+     * @param repository 保存先リポジトリ（nullの場合は旧方式でメモリに保持）
+     * @param onProgress 進捗コールバック (current, total) -> Unit
      * @return NovelWithEpisodesAndMappings（小説情報、エピソード、マッピング情報）
      */
-    suspend fun fetchNovelWithEpisodesIncludingMappings(novelId: String): NovelWithEpisodesAndMappings = withContext(Dispatchers.IO) {
+    suspend fun fetchNovelWithEpisodesIncludingMappings(
+        novelId: String,
+        repository: com.shunlight_library.novel_reader.data.repository.NovelRepository? = null,
+        onProgress: ((Int, Int) -> Unit)? = null
+    ): NovelWithEpisodesAndMappings = withContext(Dispatchers.IO) {
         val workId = if (PseudoNcodeGenerator.isKakuyomuNcode(novelId)) {
             PseudoNcodeGenerator.extractKakuyomuWorkId(novelId)
         } else {
@@ -170,39 +177,79 @@ class KakuyomuAdapter : NovelSiteAdapter {
         // エピソード一覧を抽出（本文なし）
         val episodesWithoutBody = parseEpisodeList(workId, novelDesc.ncode)
 
-        // 各エピソードの本文を取得
         android.util.Log.d("KakuyomuAdapter", "エピソード本文のダウンロード開始: ${episodesWithoutBody.size}話")
-        val episodesWithBody = episodesWithoutBody.map { episode ->
-            // episode.episode_no は連番（1, 2, 3...）なので、キャッシュから実際のIDを取得
-            val actualEpisodeId = cachedMappings[episode.episode_no.toInt()] ?: episode.episode_no
-            val episodeBody = fetchEpisodeContent(workId, actualEpisodeId)
-            episode.copy(body = episodeBody)
-        }
 
-        // エピソード数の不一致をチェック
-        val expectedCount = novelDesc.total_ep
-        val actualCount = episodesWithBody.size
+        // repositoryが指定されている場合は1話ずつ保存
+        if (repository != null) {
+            // 1話ずつ取得→保存（メモリリーク防止）
+            episodesWithoutBody.forEachIndexed { index, episode ->
+                val actualEpisodeId = cachedMappings[episode.episode_no.toInt()] ?: episode.episode_no
+                val episodeBody = fetchEpisodeContent(workId, actualEpisodeId)
+                val episodeWithBody = episode.copy(body = episodeBody)
 
-        if (expectedCount != actualCount) {
-            android.util.Log.e("KakuyomuAdapter", """
-                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-                エピソード数の不一致を検出しました！
-                - 期待されるエピソード数: ${expectedCount}話
-                - 実際に取得したエピソード数: ${actualCount}話
-                - 不足: ${expectedCount - actualCount}話
-                - 作品ID: $workId
-                - タイトル: ${novelDesc.title}
-                !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-            """.trimIndent())
+                // 1話ずつ保存
+                repository.insertEpisode(episodeWithBody)
+
+                // 進捗通知
+                onProgress?.invoke(index + 1, episodesWithoutBody.size)
+            }
+
+            // エピソード数の不一致をチェック
+            val expectedCount = novelDesc.total_ep
+            val actualCount = episodesWithoutBody.size
+
+            if (expectedCount != actualCount) {
+                android.util.Log.e("KakuyomuAdapter", """
+                    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                    エピソード数の不一致を検出しました！
+                    - 期待されるエピソード数: ${expectedCount}話
+                    - 実際に取得したエピソード数: ${actualCount}話
+                    - 不足: ${expectedCount - actualCount}話
+                    - 作品ID: $workId
+                    - タイトル: ${novelDesc.title}
+                    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                """.trimIndent())
+            } else {
+                android.util.Log.d("KakuyomuAdapter", "小説とエピソード取得完了（1話ずつ保存）: ${novelDesc.title}, ${episodesWithoutBody.size}話")
+            }
+
+            // マッピング情報をコピー
+            val mappingsCopy = cachedMappings.toMap()
+            android.util.Log.d("KakuyomuAdapter", "マッピング情報: ${mappingsCopy.size}件 (例: ${mappingsCopy.entries.take(3)})")
+
+            // 空リストを返す（すでに保存済み）
+            return@withContext NovelWithEpisodesAndMappings(novelDesc, emptyList(), mappingsCopy)
         } else {
-            android.util.Log.d("KakuyomuAdapter", "小説とエピソード取得完了: ${novelDesc.title}, ${episodesWithBody.size}話")
+            // 旧方式：全話をメモリに保持（後方互換性のため残す）
+            val episodesWithBody = episodesWithoutBody.map { episode ->
+                val actualEpisodeId = cachedMappings[episode.episode_no.toInt()] ?: episode.episode_no
+                val episodeBody = fetchEpisodeContent(workId, actualEpisodeId)
+                episode.copy(body = episodeBody)
+            }
+
+            val expectedCount = novelDesc.total_ep
+            val actualCount = episodesWithBody.size
+
+            if (expectedCount != actualCount) {
+                android.util.Log.e("KakuyomuAdapter", """
+                    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                    エピソード数の不一致を検出しました！
+                    - 期待されるエピソード数: ${expectedCount}話
+                    - 実際に取得したエピソード数: ${actualCount}話
+                    - 不足: ${expectedCount - actualCount}話
+                    - 作品ID: $workId
+                    - タイトル: ${novelDesc.title}
+                    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                """.trimIndent())
+            } else {
+                android.util.Log.d("KakuyomuAdapter", "小説とエピソード取得完了: ${novelDesc.title}, ${episodesWithBody.size}話")
+            }
+
+            val mappingsCopy = cachedMappings.toMap()
+            android.util.Log.d("KakuyomuAdapter", "マッピング情報: ${mappingsCopy.size}件 (例: ${mappingsCopy.entries.take(3)})")
+
+            return@withContext NovelWithEpisodesAndMappings(novelDesc, episodesWithBody, mappingsCopy)
         }
-
-        // マッピング情報をコピー（内部状態を外部に渡す）
-        val mappingsCopy = cachedMappings.toMap()
-        android.util.Log.d("KakuyomuAdapter", "マッピング情報: ${mappingsCopy.size}件 (例: ${mappingsCopy.entries.take(3)})")
-
-        NovelWithEpisodesAndMappings(novelDesc, episodesWithBody, mappingsCopy)
     }
 
     /**

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/SyosetuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/SyosetuAdapter.kt
@@ -94,34 +94,74 @@ class SyosetuAdapter : NovelSiteAdapter {
     }
 
     /**
-     * R18判定付きで小説情報とエピソード一覧を取得
+     * R18判定付きで小説情報とエピソード一覧を取得（1話ずつ保存）
      * Repository層から呼び出される際に使用
+     * メモリリーク防止のため、1話取得→保存→次の話、という方式で処理する。
+     *
+     * @param novelId 小説のNcode
+     * @param isR18 R18作品かどうか
+     * @param repository 保存先リポジトリ（nullの場合は旧方式でメモリに保持）
+     * @param onProgress 進捗コールバック (current, total) -> Unit
+     * @return Pair<NovelDescEntity, List<EpisodeEntity>>
      */
-    suspend fun fetchNovelWithEpisodesR18(novelId: String, isR18: Boolean): Pair<NovelDescEntity, List<EpisodeEntity>> = withContext(Dispatchers.IO) {
+    suspend fun fetchNovelWithEpisodesR18(
+        novelId: String,
+        isR18: Boolean,
+        repository: com.shunlight_library.novel_reader.data.repository.NovelRepository? = null,
+        onProgress: ((Int, Int) -> Unit)? = null
+    ): Pair<NovelDescEntity, List<EpisodeEntity>> = withContext(Dispatchers.IO) {
         // 小説情報を取得
         val novelDesc = NovelApiUtils.fetchNovelDetails(novelId, isR18)
             ?: throw Exception("Failed to fetch novel details for ncode: $novelId")
 
-        // エピソード一覧を取得
-        val episodes = mutableListOf<EpisodeEntity>()
-        for (episodeNo in 1..novelDesc.general_all_no) {
-            val episode = NovelApiUtils.fetchEpisodeWithRetry(
-                ncode = novelId,
-                episodeNo = episodeNo.toString(),
-                isR18 = isR18,
-                noveltype = novelDesc.noveltype
-            )
-            if (episode != null) {
-                episodes.add(episode)
-            } else {
-                AppLogger.w("SyosetuAdapter", "Failed to fetch episode $episodeNo for ncode: $novelId")
-            }
-        }
-
         // NovelDescEntityにsite_typeを設定
         val updatedNovelDesc = novelDesc.copy(site_type = NovelSiteAdapter.SITE_TYPE_SYOSETU)
 
-        Pair(updatedNovelDesc, episodes)
+        // repositoryが指定されている場合は1話ずつ保存
+        if (repository != null) {
+            // 1話ずつ取得→保存（メモリリーク防止）
+            for (episodeNo in 1..novelDesc.general_all_no) {
+                val episode = NovelApiUtils.fetchEpisodeWithRetry(
+                    ncode = novelId,
+                    episodeNo = episodeNo.toString(),
+                    isR18 = isR18,
+                    noveltype = novelDesc.noveltype
+                )
+
+                if (episode != null) {
+                    // 1話ずつ保存
+                    repository.insertEpisode(episode)
+                } else {
+                    AppLogger.w("SyosetuAdapter", "Failed to fetch episode $episodeNo for ncode: $novelId")
+                }
+
+                // 進捗通知
+                onProgress?.invoke(episodeNo, novelDesc.general_all_no)
+            }
+
+            AppLogger.d("SyosetuAdapter", "小説とエピソード取得完了（1話ずつ保存）: ${novelDesc.title}, ${novelDesc.general_all_no}話")
+
+            // 空リストを返す（すでに保存済み）
+            return@withContext Pair(updatedNovelDesc, emptyList())
+        } else {
+            // 旧方式：全話をメモリに保持（後方互換性のため残す）
+            val episodes = mutableListOf<EpisodeEntity>()
+            for (episodeNo in 1..novelDesc.general_all_no) {
+                val episode = NovelApiUtils.fetchEpisodeWithRetry(
+                    ncode = novelId,
+                    episodeNo = episodeNo.toString(),
+                    isR18 = isR18,
+                    noveltype = novelDesc.noveltype
+                )
+                if (episode != null) {
+                    episodes.add(episode)
+                } else {
+                    AppLogger.w("SyosetuAdapter", "Failed to fetch episode $episodeNo for ncode: $novelId")
+                }
+            }
+
+            return@withContext Pair(updatedNovelDesc, episodes)
+        }
     }
 
     /**

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -414,21 +414,46 @@ class NovelRepository(
                         // 小説家になろうの場合、URLからR18判定を取得してから小説データを取得
                         val syosetuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.SyosetuAdapter
                         val (ncode, isR18) = syosetuAdapter.extractNcodeWithR18FromUrl(url)
-                        val (novel, episodes) = syosetuAdapter.fetchNovelWithEpisodesR18(novelId, isR18)
 
-                        // DBに保存
-                        insertNovel(novel)
-                        insertEpisodes(episodes)
+                        // 1話ずつ保存する新方式
+                        val (novelDesc, _) = syosetuAdapter.fetchNovelWithEpisodesR18(
+                            novelId = novelId,
+                            isR18 = isR18,
+                            repository = this,  // 自身を渡す
+                            onProgress = { current, total ->
+                                AppLogger.d("NovelRepository", "[$novelId] エピソード取得中: $current/$total")
+                            }
+                        )
+
+                        // 小説情報を保存
+                        insertNovel(novelDesc)
+                        AppLogger.d("NovelRepository", "小説家になろう小説登録（1話ずつ保存）: ${novelDesc.title}, ${novelDesc.general_all_no}話")
                     }
                     com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_KAKUYOMU -> {
-                        // カクヨムの場合、マッピング情報も含めて取得
+                        // カクヨムの場合、マッピング情報も含めて1話ずつ保存
                         val kakuyomuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
-                        val result = kakuyomuAdapter.fetchNovelWithEpisodesIncludingMappings(novelId)
+                        val result = kakuyomuAdapter.fetchNovelWithEpisodesIncludingMappings(
+                            novelId = novelId,
+                            repository = this,  // 自身を渡す
+                            onProgress = { current, total ->
+                                AppLogger.d("NovelRepository", "[$novelId] エピソード取得中: $current/$total")
+                            }
+                        )
 
-                        // DBに保存（マッピング情報も含む）
+                        // 小説情報を保存
                         insertNovel(result.novelDesc)
-                        insertKakuyomuEpisodesWithMappings(result.episodes, result.episodeMappings)
-                        AppLogger.d("NovelRepository", "カクヨム小説登録: ${result.novelDesc.title}, エピソード: ${result.episodes.size}話, マッピング: ${result.episodeMappings.size}件")
+
+                        // マッピング情報を保存
+                        val mappingEntities = result.episodeMappings.map { (episodeNo, kakuyomuId) ->
+                            com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity(
+                                ncode = result.novelDesc.ncode,
+                                episode_no = episodeNo,
+                                kakuyomu_episode_id = kakuyomuId
+                            )
+                        }
+                        insertEpisodeMappings(mappingEntities)
+
+                        AppLogger.d("NovelRepository", "カクヨム小説登録（1話ずつ保存）: ${result.novelDesc.title}, マッピング: ${result.episodeMappings.size}件")
                     }
                     else -> {
                         // その他のサイトは通常の取得方法
@@ -499,24 +524,47 @@ class NovelRepository(
                 // 小説情報とエピソード一覧を取得
                 when (adapter.getSiteType()) {
                     com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_SYOSETU -> {
-                        // 小説家になろうの場合、R18判定を渡す
+                        // 小説家になろうの場合、R18判定を渡して1話ずつ保存
                         val syosetuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.SyosetuAdapter
-                        val (novel, episodes) = syosetuAdapter.fetchNovelWithEpisodesR18(ncode, isR18)
+                        val (novelDesc, _) = syosetuAdapter.fetchNovelWithEpisodesR18(
+                            novelId = ncode,
+                            isR18 = isR18,
+                            repository = this,  // 自身を渡す
+                            onProgress = { current, total ->
+                                AppLogger.d("NovelRepository", "[$ncode] エピソード取得中: $current/$total")
+                            }
+                        )
 
-                        // DBに保存
-                        insertNovel(novel)
-                        insertEpisodes(episodes)
+                        // 小説情報を保存
+                        insertNovel(novelDesc)
+                        AppLogger.d("NovelRepository", "小説家になろう小説登録（1話ずつ保存）: ${novelDesc.title}, ${novelDesc.general_all_no}話")
                     }
                     com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_KAKUYOMU -> {
-                        // カクヨムの場合、Pseudo-NcodeからworkIdを抽出してマッピング情報も含めて取得
+                        // カクヨムの場合、Pseudo-NcodeからworkIdを抽出してマッピング情報も含めて1話ずつ保存
                         val workId = com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator.extractKakuyomuWorkId(ncode)
                         val kakuyomuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
-                        val result = kakuyomuAdapter.fetchNovelWithEpisodesIncludingMappings(workId)
+                        val result = kakuyomuAdapter.fetchNovelWithEpisodesIncludingMappings(
+                            novelId = workId,
+                            repository = this,  // 自身を渡す
+                            onProgress = { current, total ->
+                                AppLogger.d("NovelRepository", "[$ncode] エピソード取得中: $current/$total")
+                            }
+                        )
 
-                        // DBに保存（マッピング情報も含む）
+                        // 小説情報を保存
                         insertNovel(result.novelDesc)
-                        insertKakuyomuEpisodesWithMappings(result.episodes, result.episodeMappings)
-                        AppLogger.d("NovelRepository", "カクヨム小説登録: ${result.novelDesc.title}, エピソード: ${result.episodes.size}話, マッピング: ${result.episodeMappings.size}件")
+
+                        // マッピング情報を保存
+                        val mappingEntities = result.episodeMappings.map { (episodeNo, kakuyomuId) ->
+                            com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity(
+                                ncode = result.novelDesc.ncode,
+                                episode_no = episodeNo,
+                                kakuyomu_episode_id = kakuyomuId
+                            )
+                        }
+                        insertEpisodeMappings(mappingEntities)
+
+                        AppLogger.d("NovelRepository", "カクヨム小説登録（1話ずつ保存）: ${result.novelDesc.title}, マッピング: ${result.episodeMappings.size}件")
                     }
                     else -> {
                         // その他のサイト

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/receiver/DownloadAllReceiver.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/receiver/DownloadAllReceiver.kt
@@ -1,0 +1,41 @@
+/*
+ * eightman 2005-2025
+ * Furin-lab All Rights Reserved.
+ * BroadcastReceiver for handling "Download All" action from notifications
+ */
+package com.shunlight_library.novel_reader.receiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.shunlight_library.novel_reader.service.UpdateService
+
+/**
+ * 通知からの「すべてダウンロード」アクション処理を行うBroadcastReceiver
+ *
+ * 自動更新の通知に表示される「すべてダウンロード」ボタンをタップすると、
+ * このレシーバーが起動され、UpdateServiceを使って一括ダウンロードを実行する。
+ */
+class DownloadAllReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val ACTION_DOWNLOAD_ALL = "com.shunlight_library.novel_reader.ACTION_DOWNLOAD_ALL"
+        private const val TAG = "DownloadAllReceiver"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == ACTION_DOWNLOAD_ALL) {
+            Log.d(TAG, "ダウンロールボタンがタップされました")
+
+            // UpdateServiceを起動して一括ダウンロードを実行
+            val serviceIntent = Intent(context, UpdateService::class.java).apply {
+                action = UpdateService.ACTION_START_UPDATE
+                putExtra(UpdateService.EXTRA_UPDATE_TYPE, UpdateService.UPDATE_TYPE_BULK_UPDATE)
+            }
+            context.startService(serviceIntent)
+
+            Log.d(TAG, "UpdateServiceで一括ダウンロードを開始しました")
+        }
+    }
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -244,7 +244,7 @@ class AutoUpdateWorker(
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle(title)
             .setContentText(content)
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)  // プッシュ通知として表示
             .setContentIntent(pendingIntent)
             .addAction(
                 android.R.drawable.stat_sys_download_done,
@@ -311,7 +311,7 @@ class AutoUpdateWorker(
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .setContentTitle("自動更新エラー")
             .setContentText("更新処理中にエラーが発生しました: $message")
-            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)  // プッシュ通知として表示
             .setAutoCancel(true)
             .build()
         notificationManager.notify(NOTIFICATION_ID + 1, notification)
@@ -330,11 +330,13 @@ class AutoUpdateWorker(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val name = "小説更新通知"
             val descriptionText = "小説の更新を通知します"
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
+            val importance = NotificationManager.IMPORTANCE_HIGH  // プッシュ通知として表示
             val channel = NotificationChannel(NOTIFICATION_CHANNEL_ID, name, importance).apply {
                 description = descriptionText
+                enableVibration(true)  // バイブレーション有効化
+                enableLights(true)     // LED通知有効化
             }
-            
+
             val notificationManager = applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             notificationManager.createNotificationChannel(channel)
         }


### PR DESCRIPTION
【変更内容】

1. 新規登録を1話ずつ保存する方式に変更（メモリリーク防止）
   - KakuyomuAdapter: fetchNovelWithEpisodesIncludingMappings()に repositoryとonProgressコールバックを追加、1話ずつ保存
   - SyosetuAdapter: fetchNovelWithEpisodesR18()に同様の対応
   - NovelRepository: addNovelByUrl()とaddNovelByNcode()で Adapterに自身を渡して段階的保存を実現
   - メリット: 992話のような大規模作品でもメモリ効率が良い、 中断時も取得済みエピソードは保存される

2. 更新ダイアログに改稿チェックを追加
   - UpdateType enumにCHECK_REVISIONを追加
   - EpisodeListScreenの更新ダイアログにRadioButtonを追加
   - performCheckRevision()関数を実装（カクヨム・短編は非対応）
   - メニューから重複していた改稿チェックを削除

3. 自動更新の通知改善（プッシュ通知+ダウンロードボタン）
   - DownloadAllReceiverを新規作成
   - AndroidManifestにBroadcastReceiverを登録
   - 通知チャンネルの重要度をIMPORTANCE_HIGHに変更
   - 通知の優先度をPRIORITY_HIGHに変更
   - バイブレーションとLED通知を有効化
   - アプリが閉じていてもプッシュ通知として表示される
   - 「すべてダウンロード」ボタンでワンタップ一括DL可能