### PR TITLE
Fix CoroutineScope type mismatch in NovelRepository

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 149
-        versionName = "1.5.26"
+        versionCode = 150
+        versionName = "1.5.27"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -419,7 +419,7 @@ class NovelRepository(
                         val (novelDesc, _) = syosetuAdapter.fetchNovelWithEpisodesR18(
                             novelId = novelId,
                             isR18 = isR18,
-                            repository = this,  // 自身を渡す
+                            repository = this@NovelRepository,  // 自身を渡す
                             onProgress = { current, total ->
                                 AppLogger.d("NovelRepository", "[$novelId] エピソード取得中: $current/$total")
                             }
@@ -434,7 +434,7 @@ class NovelRepository(
                         val kakuyomuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
                         val result = kakuyomuAdapter.fetchNovelWithEpisodesIncludingMappings(
                             novelId = novelId,
-                            repository = this,  // 自身を渡す
+                            repository = this@NovelRepository,  // 自身を渡す
                             onProgress = { current, total ->
                                 AppLogger.d("NovelRepository", "[$novelId] エピソード取得中: $current/$total")
                             }
@@ -529,7 +529,7 @@ class NovelRepository(
                         val (novelDesc, _) = syosetuAdapter.fetchNovelWithEpisodesR18(
                             novelId = ncode,
                             isR18 = isR18,
-                            repository = this,  // 自身を渡す
+                            repository = this@NovelRepository,  // 自身を渡す
                             onProgress = { current, total ->
                                 AppLogger.d("NovelRepository", "[$ncode] エピソード取得中: $current/$total")
                             }
@@ -545,7 +545,7 @@ class NovelRepository(
                         val kakuyomuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
                         val result = kakuyomuAdapter.fetchNovelWithEpisodesIncludingMappings(
                             novelId = workId,
-                            repository = this,  // 自身を渡す
+                            repository = this@NovelRepository,  // 自身を渡す
                             onProgress = { current, total ->
                                 AppLogger.d("NovelRepository", "[$ncode] エピソード取得中: $current/$total")
                             }


### PR DESCRIPTION
- NovelRepository.ktの4箇所で`this`を`this@NovelRepository`に修正
- withContext(Dispatchers.IO)ブロック内では`this`がCoroutineScopeを指すため、NovelRepositoryインスタンスを参照するには`this@NovelRepository`を使用する必要がある
- バージョンを150/1.5.27に更新