### PR TITLE
Fetch release notes with app updates

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 154
-        versionName = "1.5.31"
+        versionCode = 155
+        versionName = "1.5.32"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -57,6 +57,9 @@ dependencies {
 
 // Jsoup for HTML parsing
     implementation("org.jsoup:jsoup:1.16.1")
+
+// Markdown rendering for Compose
+    implementation("com.github.jeziellago:compose-markdown:0.5.4")
 
 // DataStore for preferences
     implementation ("androidx.compose.material:material-icons-extended:1.7.0")

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/NotificationData.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/NotificationData.kt
@@ -24,7 +24,13 @@ data class AppNotification(
     val content: String,
     val timestamp: Long,
     val isRead: Boolean = false,
-    val type: NotificationType = NotificationType.UPDATE
+    val type: NotificationType = NotificationType.UPDATE,
+    // リリース情報用フィールド（リリース通知の場合のみ使用）
+    val releaseTagName: String? = null,
+    val releaseName: String? = null,
+    val releaseBody: String? = null,
+    val releasePublishedAt: String? = null,
+    val releaseUrl: String? = null
 )
 
 enum class NotificationType {
@@ -43,6 +49,12 @@ class NotificationStore(private val context: Context) {
         private const val NOTIFICATION_TIMESTAMP_PREFIX = "notification_timestamp_"
         private const val NOTIFICATION_TYPE_PREFIX = "notification_type_"
         private const val NOTIFICATION_READ_PREFIX = "notification_read_"
+        // リリース情報用キー
+        private const val NOTIFICATION_RELEASE_TAG_PREFIX = "notification_release_tag_"
+        private const val NOTIFICATION_RELEASE_NAME_PREFIX = "notification_release_name_"
+        private const val NOTIFICATION_RELEASE_BODY_PREFIX = "notification_release_body_"
+        private const val NOTIFICATION_RELEASE_PUBLISHED_PREFIX = "notification_release_published_"
+        private const val NOTIFICATION_RELEASE_URL_PREFIX = "notification_release_url_"
     }
 
     suspend fun addNotification(notification: AppNotification) {
@@ -57,6 +69,23 @@ class NotificationStore(private val context: Context) {
             preferences[longPreferencesKey("${NOTIFICATION_TIMESTAMP_PREFIX}${notification.id}")] = notification.timestamp
             preferences[stringPreferencesKey("${NOTIFICATION_TYPE_PREFIX}${notification.id}")] = notification.type.name
             preferences[booleanPreferencesKey("${NOTIFICATION_READ_PREFIX}${notification.id}")] = notification.isRead
+
+            // リリース情報を保存（nullでない場合のみ）
+            notification.releaseTagName?.let {
+                preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_TAG_PREFIX}${notification.id}")] = it
+            }
+            notification.releaseName?.let {
+                preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_NAME_PREFIX}${notification.id}")] = it
+            }
+            notification.releaseBody?.let {
+                preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_BODY_PREFIX}${notification.id}")] = it
+            }
+            notification.releasePublishedAt?.let {
+                preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_PUBLISHED_PREFIX}${notification.id}")] = it
+            }
+            notification.releaseUrl?.let {
+                preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_URL_PREFIX}${notification.id}")] = it
+            }
 
             enforceNotificationLimit(preferences)
         }
@@ -89,6 +118,12 @@ class NotificationStore(private val context: Context) {
             preferences.remove(longPreferencesKey("${NOTIFICATION_TIMESTAMP_PREFIX}${id}"))
             preferences.remove(stringPreferencesKey("${NOTIFICATION_TYPE_PREFIX}${id}"))
             preferences.remove(booleanPreferencesKey("${NOTIFICATION_READ_PREFIX}${id}"))
+            // リリース情報も削除
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_TAG_PREFIX}${id}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_NAME_PREFIX}${id}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_BODY_PREFIX}${id}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_PUBLISHED_PREFIX}${id}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_URL_PREFIX}${id}"))
         }
     }
 
@@ -102,7 +137,14 @@ class NotificationStore(private val context: Context) {
             val timestamp = preferences[longPreferencesKey("${NOTIFICATION_TIMESTAMP_PREFIX}${id}")]
             val typeString = preferences[stringPreferencesKey("${NOTIFICATION_TYPE_PREFIX}${id}")]
             val isRead = preferences[booleanPreferencesKey("${NOTIFICATION_READ_PREFIX}${id}")] ?: false
-            
+
+            // リリース情報を読み込み（nullableなので存在しない場合はnull）
+            val releaseTagName = preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_TAG_PREFIX}${id}")]
+            val releaseName = preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_NAME_PREFIX}${id}")]
+            val releaseBody = preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_BODY_PREFIX}${id}")]
+            val releasePublishedAt = preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_PUBLISHED_PREFIX}${id}")]
+            val releaseUrl = preferences[stringPreferencesKey("${NOTIFICATION_RELEASE_URL_PREFIX}${id}")]
+
             if (title != null && content != null && timestamp != null && typeString != null) {
                 AppNotification(
                     id = id,
@@ -110,7 +152,12 @@ class NotificationStore(private val context: Context) {
                     content = content,
                     timestamp = timestamp,
                     isRead = isRead,
-                    type = try { NotificationType.valueOf(typeString) } catch (e: Exception) { NotificationType.INFO }
+                    type = try { NotificationType.valueOf(typeString) } catch (e: Exception) { NotificationType.INFO },
+                    releaseTagName = releaseTagName,
+                    releaseName = releaseName,
+                    releaseBody = releaseBody,
+                    releasePublishedAt = releasePublishedAt,
+                    releaseUrl = releaseUrl
                 )
             } else null
         }.sortedByDescending { it.timestamp }
@@ -140,13 +187,19 @@ class NotificationStore(private val context: Context) {
             // IDリストから削除
             val currentNotifications = preferences[PENDING_NOTIFICATIONS] ?: emptySet()
             preferences[PENDING_NOTIFICATIONS] = currentNotifications - notificationId
-            
+
             // 関連データも削除
             preferences.remove(stringPreferencesKey("${NOTIFICATION_TITLE_PREFIX}${notificationId}"))
             preferences.remove(stringPreferencesKey("${NOTIFICATION_CONTENT_PREFIX}${notificationId}"))
             preferences.remove(longPreferencesKey("${NOTIFICATION_TIMESTAMP_PREFIX}${notificationId}"))
             preferences.remove(stringPreferencesKey("${NOTIFICATION_TYPE_PREFIX}${notificationId}"))
             preferences.remove(booleanPreferencesKey("${NOTIFICATION_READ_PREFIX}${notificationId}"))
+            // リリース情報も削除
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_TAG_PREFIX}${notificationId}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_NAME_PREFIX}${notificationId}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_BODY_PREFIX}${notificationId}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_PUBLISHED_PREFIX}${notificationId}"))
+            preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_URL_PREFIX}${notificationId}"))
         }
     }
 
@@ -155,7 +208,7 @@ class NotificationStore(private val context: Context) {
         context.notificationDataStore.edit { preferences ->
             // IDリストをクリア
             preferences[PENDING_NOTIFICATIONS] = emptySet()
-            
+
             // 全ての関連データを削除
             notifications.forEach { notification ->
                 preferences.remove(stringPreferencesKey("${NOTIFICATION_TITLE_PREFIX}${notification.id}"))
@@ -163,6 +216,12 @@ class NotificationStore(private val context: Context) {
                 preferences.remove(longPreferencesKey("${NOTIFICATION_TIMESTAMP_PREFIX}${notification.id}"))
                 preferences.remove(stringPreferencesKey("${NOTIFICATION_TYPE_PREFIX}${notification.id}"))
                 preferences.remove(booleanPreferencesKey("${NOTIFICATION_READ_PREFIX}${notification.id}"))
+                // リリース情報も削除
+                preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_TAG_PREFIX}${notification.id}"))
+                preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_NAME_PREFIX}${notification.id}"))
+                preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_BODY_PREFIX}${notification.id}"))
+                preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_PUBLISHED_PREFIX}${notification.id}"))
+                preferences.remove(stringPreferencesKey("${NOTIFICATION_RELEASE_URL_PREFIX}${notification.id}"))
             }
         }
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/components/NotificationDialog.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/components/NotificationDialog.kt
@@ -5,15 +5,21 @@
  */
 package com.shunlight_library.novel_reader.ui.components
 
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -21,6 +27,7 @@ import androidx.compose.ui.unit.sp
 import com.shunlight_library.novel_reader.data.AppNotification
 import com.shunlight_library.novel_reader.data.NotificationStore
 import com.shunlight_library.novel_reader.data.NotificationType
+import dev.jeziellago.compose.markdowntext.MarkdownText
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.*
@@ -32,6 +39,7 @@ fun NotificationDialog(
     onDismiss: () -> Unit
 ) {
     var notifications by remember { mutableStateOf<List<AppNotification>>(emptyList()) }
+    var selectedRelease by remember { mutableStateOf<AppNotification?>(null) }
     val scope = rememberCoroutineScope()
 
     // 通知データを読み込み
@@ -39,6 +47,14 @@ fun NotificationDialog(
         scope.launch {
             notifications = notificationStore.getAllNotifications()
         }
+    }
+
+    // リリース詳細ダイアログ
+    selectedRelease?.let { release ->
+        ReleaseDetailDialog(
+            release = release,
+            onDismiss = { selectedRelease = null }
+        )
     }
 
     AlertDialog(
@@ -99,6 +115,12 @@ fun NotificationDialog(
                     items(notifications) { notification ->
                         NotificationItem(
                             notification = notification,
+                            onClick = {
+                                // リリース通知の場合、詳細ダイアログを表示
+                                if (notification.releaseBody != null) {
+                                    selectedRelease = notification
+                                }
+                            },
                             onMarkAsRead = {
                                 if (!notification.isRead) {
                                     scope.launch {
@@ -143,6 +165,7 @@ fun NotificationDialog(
 @Composable
 fun NotificationItem(
     notification: AppNotification,
+    onClick: () -> Unit,
     onMarkAsRead: () -> Unit,
     onDelete: () -> Unit
 ) {
@@ -150,7 +173,9 @@ fun NotificationItem(
     val formattedDate = dateFormat.format(Date(notification.timestamp))
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = notification.releaseBody != null) { onClick() },
         colors = CardDefaults.cardColors(
             containerColor = if (notification.isRead) {
                 MaterialTheme.colorScheme.surface
@@ -240,5 +265,103 @@ fun NotificationItem(
                 }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReleaseDetailDialog(
+    release: AppNotification,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    val scrollState = rememberScrollState()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Column {
+                Text(
+                    text = release.releaseName ?: release.releaseTagName ?: "リリース詳細",
+                    style = MaterialTheme.typography.titleLarge
+                )
+                if (!release.releaseTagName.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = release.releaseTagName!!,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                }
+                if (!release.releasePublishedAt.isNullOrEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "公開日時: ${formatPublishedDate(release.releasePublishedAt!!)}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                }
+            }
+        },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 500.dp)
+                    .verticalScroll(scrollState)
+            ) {
+                if (!release.releaseBody.isNullOrEmpty()) {
+                    MarkdownText(
+                        markdown = release.releaseBody!!,
+                        modifier = Modifier.fillMaxWidth(),
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                } else {
+                    Text(
+                        text = "リリースノートはありません",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            if (!release.releaseUrl.isNullOrEmpty()) {
+                Button(
+                    onClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(release.releaseUrl))
+                        context.startActivity(intent)
+                    }
+                ) {
+                    Icon(
+                        Icons.Default.OpenInNew,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text("GitHubで開く")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("閉じる")
+            }
+        }
+    )
+}
+
+/**
+ * ISO 8601形式の日時を読みやすい形式に変換
+ */
+private fun formatPublishedDate(isoDate: String): String {
+    if (isoDate.isEmpty()) return "不明"
+    return try {
+        val instant = java.time.Instant.parse(isoDate)
+        val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+            .withZone(java.time.ZoneId.systemDefault())
+        formatter.format(instant)
+    } catch (e: Exception) {
+        isoDate
     }
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/utils/ReleaseUtils.kt
@@ -68,21 +68,37 @@ object ReleaseUtils {
                 if (connection.responseCode == HttpURLConnection.HTTP_OK) {
                     val response = BufferedReader(InputStreamReader(connection.inputStream)).use { it.readText() }
                     val json = JSONObject(response)
-                    val tag = json.getString("tag_name")
+
+                    // リリース情報を取得
+                    val tagName = json.getString("tag_name")
+                    val name = json.optString("name", tagName)
+                    val body = json.optString("body", "")
+                    val publishedAt = json.optString("published_at", "")
+                    val htmlUrl = json.optString("html_url", RELEASE_PAGE)
+
                     val store = SettingsStore(context)
                     val last = store.getLastNotifiedRelease()
-                    if (isNewerVersion(tag, AppInfo.VERSION_NAME) && last != tag) {
-                        sendSystemNotification(context, tag)
+                    if (isNewerVersion(tagName, AppInfo.VERSION_NAME) && last != tagName) {
+                        sendSystemNotification(context, tagName, name, publishedAt)
                         NotificationStore(context).addNotification(
                             AppNotification(
                                 id = "release_${System.currentTimeMillis()}",
-                                title = "新しいバージョン $tag",
-                                content = "GitHubに新しいリリースがあります",
+                                title = "新しいバージョン $tagName",
+                                content = if (name.isNotEmpty() && name != tagName) {
+                                    "$name\n公開日時: ${formatPublishedDate(publishedAt)}"
+                                } else {
+                                    "公開日時: ${formatPublishedDate(publishedAt)}"
+                                },
                                 timestamp = System.currentTimeMillis(),
-                                type = NotificationType.INFO
+                                type = NotificationType.INFO,
+                                releaseTagName = tagName,
+                                releaseName = name,
+                                releaseBody = body,
+                                releasePublishedAt = publishedAt,
+                                releaseUrl = htmlUrl
                             )
                         )
-                        store.saveLastNotifiedRelease(tag)
+                        store.saveLastNotifiedRelease(tagName)
                     }
                 }
             } catch (e: Exception) {
@@ -96,9 +112,11 @@ object ReleaseUtils {
     /**
      * 新しいバージョンをシステム通知で知らせる
      * @param context コンテキスト
-     * @param version 新しいバージョン名
+     * @param tagName バージョンタグ名
+     * @param name リリース名
+     * @param publishedAt 公開日時（ISO 8601形式）
      */
-    private fun sendSystemNotification(context: Context, version: String) {
+    private fun sendSystemNotification(context: Context, tagName: String, name: String, publishedAt: String) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             val channel = NotificationChannel(CHANNEL_ID, "Updates", NotificationManager.IMPORTANCE_DEFAULT)
@@ -111,15 +129,43 @@ object ReleaseUtils {
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         )
+
+        // 通知のタイトルと内容を構築
+        val title = if (name.isNotEmpty() && name != tagName) {
+            "新しいバージョン $tagName - $name"
+        } else {
+            "新しいバージョン $tagName"
+        }
+        val content = "公開日時: ${formatPublishedDate(publishedAt)}"
+
         val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_launcher_foreground)
-            .setContentTitle("新しいバージョン $version")
-            .setContentText("GitHubで新しいリリースが公開されています")
+            .setContentTitle(title)
+            .setContentText(content)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
             .build()
         manager.notify(NOTIFICATION_ID, notification)
+    }
+
+    /**
+     * ISO 8601形式の日時を読みやすい形式に変換
+     * @param isoDate ISO 8601形式の日時（例: "2025-11-28T12:00:00Z"）
+     * @return フォーマット済みの日時文字列（例: "2025-11-28 12:00"）
+     */
+    private fun formatPublishedDate(isoDate: String): String {
+        if (isoDate.isEmpty()) return "不明"
+        return try {
+            // ISO 8601形式をパース（例: 2025-11-28T12:00:00Z）
+            val instant = java.time.Instant.parse(isoDate)
+            val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+                .withZone(java.time.ZoneId.systemDefault())
+            formatter.format(instant)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to parse date: $isoDate", e)
+            isoDate
+        }
     }
 }

--- a/Novel_reader/settings.gradle.kts
+++ b/Novel_reader/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
- AppNotificationにリリース情報用フィールドを追加（releaseTagName, releaseName, releaseBody, releasePublishedAt, releaseUrl）
- NotificationStoreでリリース情報の保存・読み込みをサポート
- ReleaseUtilsを拡張してGitHub APIから完全なリリース情報を取得
- システム通知にtag_name、name、published_atを表示
- NotificationDialogにリリース詳細ポップアップを追加
  - マークダウンレンダリング機能を実装
  - 「GitHubで開く」ボタンを追加
  - スクロール可能な本文表示
- compose-markdownライブラリを追加（JitPackリポジトリを使用）
- バージョンを1.5.32 (versionCode 155)に更新