### PR TITLE
Fix episode update detection and read status loss

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 155
-        versionName = "1.5.32"
+        versionCode = 156
+        versionName = "1.5.33"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -586,8 +586,8 @@ fun UpdateInfoScreen(
                                                                                 syncMessage = "「${novel.title}」のエピソード一覧を更新中..."
                                                                                 val (_, refreshedEpisodes) = adapter.fetchNovelMetadataWithEpisodeList(novel.ncode)
 
-                                                                                // エピソード情報をデータベースに保存
-                                                                                repository.insertEpisodes(refreshedEpisodes)
+                                                                                // エピソード情報をデータベースに保存（既読情報を保持）
+                                                                                repository.insertEpisodesPreservingReadStatus(refreshedEpisodes)
 
                                                                                 // マッピング情報をデータベースに保存
                                                                                 val mappings = adapter.getCachedMappings().map { (episodeNoInt, kakuyomuEpisodeId) ->
@@ -601,7 +601,7 @@ fun UpdateInfoScreen(
 
                                                                                 Log.d(
                                                                                     "UpdateInfo",
-                                                                                    "カクヨムエピソード一覧とマッピング情報を再取得完了: ${novel.ncode}, ${refreshedEpisodes.size}話, mapping: ${mappings.size}件"
+                                                                                    "カクヨムエピソード一覧とマッピング情報を再取得完了（既読情報保持）: ${novel.ncode}, ${refreshedEpisodes.size}話, mapping: ${mappings.size}件"
                                                                                 )
 
                                                                                 // 再取得フラグを立てる（小説ごとに1回のみ）

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -78,10 +78,56 @@ class NovelRepository(
     }
 
     /**
+     * エピソードを保存（既読情報を保持）
+     *
+     * 既存のエピソードがある場合、既読情報（is_read、is_bookmark、reading_rate）を保持してマージする。
+     * これにより、小説の再取得や更新時に既読情報が失われるのを防ぐ。
+     *
+     * @param episodes 保存するエピソードリスト
+     */
+    suspend fun insertEpisodesPreservingReadStatus(episodes: List<EpisodeEntity>) {
+        withContext(Dispatchers.IO) {
+            if (episodes.isEmpty()) {
+                android.util.Log.w("NovelRepository", "エピソードリストが空です")
+                return@withContext
+            }
+
+            val ncode = episodes.first().ncode
+
+            // 既存のエピソードを取得（既読情報を保持するため）
+            val existingEpisodes = episodeDao.getEpisodesByNcode(ncode)
+            val existingEpisodesSnapshot = kotlinx.coroutines.flow.first(existingEpisodes)
+            val existingMap = existingEpisodesSnapshot.associateBy { it.episode_no }
+
+            // 新しいエピソードと既存のエピソードをマージ（既読情報を保持）
+            val mergedEpisodes = episodes.map { newEpisode ->
+                val existing = existingMap[newEpisode.episode_no]
+                if (existing != null) {
+                    // 既存のエピソードがある場合、既読情報を保持
+                    newEpisode.copy(
+                        is_read = existing.is_read,
+                        is_bookmark = existing.is_bookmark,
+                        reading_rate = existing.reading_rate
+                    )
+                } else {
+                    // 新しいエピソード（既読情報はデフォルト値）
+                    newEpisode
+                }
+            }
+
+            // マージしたエピソードを保存
+            episodeDao.insertEpisodes(mergedEpisodes)
+            android.util.Log.d("NovelRepository", "エピソード保存（既読情報保持）: ${mergedEpisodes.size}件 (ncode=$ncode, 既存: ${existingMap.size}件, 新規: ${mergedEpisodes.size - existingMap.size}件)")
+        }
+    }
+
+    /**
      * カクヨム小説のエピソードとマッピングを一括保存
      *
      * このメソッドは再取得・更新処理でエピソードマッピング情報を確実に保存する。
      * エピソード番号（連番）とカクヨムの実際のエピソードIDの対応を保持する。
+     *
+     * **重要**: 既存のエピソードの既読情報（is_read、is_bookmark、reading_rate）を保持する。
      *
      * @param episodes エピソードリスト（episode_noは連番）
      * @param mappings エピソード番号（連番）→カクヨムEpisodeIDのマッピング
@@ -98,9 +144,30 @@ class NovelRepository(
 
             val ncode = episodes.first().ncode
 
-            // エピソードを保存
-            episodeDao.insertEpisodes(episodes)
-            android.util.Log.d("NovelRepository", "カクヨムエピソード保存: ${episodes.size}件 (ncode=$ncode)")
+            // 既存のエピソードを取得（既読情報を保持するため）
+            val existingEpisodes = episodeDao.getEpisodesByNcode(ncode)
+            val existingEpisodesSnapshot = kotlinx.coroutines.flow.first(existingEpisodes)
+            val existingMap = existingEpisodesSnapshot.associateBy { it.episode_no }
+
+            // 新しいエピソードと既存のエピソードをマージ（既読情報を保持）
+            val mergedEpisodes = episodes.map { newEpisode ->
+                val existing = existingMap[newEpisode.episode_no]
+                if (existing != null) {
+                    // 既存のエピソードがある場合、既読情報を保持
+                    newEpisode.copy(
+                        is_read = existing.is_read,
+                        is_bookmark = existing.is_bookmark,
+                        reading_rate = existing.reading_rate
+                    )
+                } else {
+                    // 新しいエピソード（既読情報はデフォルト値）
+                    newEpisode
+                }
+            }
+
+            // マージしたエピソードを保存
+            episodeDao.insertEpisodes(mergedEpisodes)
+            android.util.Log.d("NovelRepository", "カクヨムエピソード保存: ${mergedEpisodes.size}件 (ncode=$ncode, 既存: ${existingMap.size}件, 新規: ${mergedEpisodes.size - existingMap.size}件)")
 
             // マッピング情報を保存
             val mappingEntities = mappings.map { (episodeNo, kakuyomuId) ->

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -138,17 +138,13 @@ class AutoUpdateWorker(
                                     apiInfo?.generalAllNo ?: novel.total_ep
                                 }
                                 com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter.SITE_TYPE_KAKUYOMU -> {
-                                    // カクヨムの場合、checkForUpdatesを使用してHTMLから取得
+                                    // カクヨムの場合、軽量なメタデータ取得メソッドを使用（本文は取得しない）
+                                    val kakuyomuAdapter = adapter as com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
                                     val workId = com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator.extractKakuyomuWorkId(novel.ncode)
-                                    val hasUpdate = adapter.checkForUpdates(workId, novel.total_ep)
 
-                                    if (hasUpdate) {
-                                        // 更新がある場合のみ詳細を取得
-                                        val (updatedNovel, _) = adapter.fetchNovelWithEpisodes(workId)
-                                        updatedNovel.total_ep
-                                    } else {
-                                        novel.total_ep
-                                    }
+                                    // メタデータのみ取得（本文は含まない）
+                                    val (updatedNovel, _) = kakuyomuAdapter.fetchNovelMetadataWithEpisodeList(workId)
+                                    updatedNovel.total_ep
                                 }
                                 else -> novel.total_ep
                             }


### PR DESCRIPTION
- AutoUpdateWorker.kt: カクヨム更新確認時に軽量なメタデータ取得を使用（本文の不要なダウンロードを回避）
- NovelRepository.kt: 既読情報保持メソッドを追加（insertEpisodesPreservingReadStatus、insertKakuyomuEpisodesWithMappings改善）
- UpdateInfoScreen.kt: エピソード一覧更新時に既読情報を保持
- build.gradle.kts: バージョンを1.5.33（versionCode: 156）に更新

修正内容:
1. 自動更新確認でカクヨムの全エピソード本文を不要にダウンロードしていた問題を修正
2. カクヨムの更新時に既読情報（is_read、is_bookmark、reading_rate）が失われる問題を修正