### PR TITLE
Add configurable indicator lamp animation

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 156
-        versionName = "1.5.33"
+        versionCode = 157
+        versionName = "1.5.34"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -49,6 +49,8 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import com.shunlight_library.novel_reader.metadata.MetadataUpdateManager
 import com.shunlight_library.novel_reader.metadata.MetadataUpdateResult
+import com.shunlight_library.novel_reader.ui.components.IndicatorLampGroup
+import com.shunlight_library.novel_reader.ui.components.IndicatorLampStyle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -173,6 +175,18 @@ fun NovelReaderApp(
     // リポジトリを取得
     val repository = NovelReaderApplication.getRepository()
 
+    // インジケーターランプの設定を取得
+    val settingsStore = remember { SettingsStore(context) }
+    val indicatorEnabled by settingsStore.indicatorLampEnabled.collectAsState(initial = true)
+    val indicatorStyleStr by settingsStore.indicatorLampStyle.collectAsState(initial = "SOLID")
+    val indicatorStyle = when (indicatorStyleStr) {
+        "BLINKING" -> IndicatorLampStyle.BLINKING
+        else -> IndicatorLampStyle.SOLID
+    }
+
+    // 処理状態を監視
+    val processingStates by repository.processingStates.collectAsState()
+
     // 最後に読んだ小説の情報を取得
     var lastReadNovel by remember { mutableStateOf<LastReadNovelEntity?>(null) }
     var novelInfo by remember { mutableStateOf<NovelDescEntity?>(null) }
@@ -258,7 +272,10 @@ fun NovelReaderApp(
         }
     }
 
-when (val currentScreen = navigationManager.currentScreen) {
+    // インジケーターランプとコンテンツを重ねて表示
+    Box(modifier = Modifier.fillMaxSize()) {
+        // メインコンテンツ
+        when (val currentScreen = navigationManager.currentScreen) {
         is Screen.Main -> {
             MainScreen(
                 onNavigate = { screen -> navigationManager.navigateTo(screen) },
@@ -382,8 +399,21 @@ when (val currentScreen = navigationManager.currentScreen) {
                 CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
             }
         }
+        }
 
-
+        // インジケーターランプを左下に表示
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(16.dp)
+                .navigationBarsPadding()
+        ) {
+            IndicatorLampGroup(
+                states = processingStates,
+                style = indicatorStyle,
+                enabled = indicatorEnabled
+            )
+        }
     }
 }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
@@ -92,6 +92,10 @@ fun SettingsScreenUpdated(
     var autoUpdateEnabled by remember { mutableStateOf(false) }
     var autoUpdateTime by remember { mutableStateOf("03:00") }
 
+    // インジケーターランプ設定の状態変数
+    var indicatorLampEnabled by remember { mutableStateOf(true) }
+    var indicatorLampStyle by remember { mutableStateOf("SOLID") }
+
     // カスタムフォント関連の状態変数
     var customFonts by remember { mutableStateOf<List<CustomFontInfo>>(emptyList()) }
     var showCustomFontDialog by remember { mutableStateOf(false) }
@@ -222,6 +226,10 @@ fun SettingsScreenUpdated(
             // 自動更新設定の読み込み
             autoUpdateEnabled = settingsStore.autoUpdateEnabled.first()
             autoUpdateTime = settingsStore.autoUpdateTime.first()
+
+            // インジケーターランプ設定の読み込み
+            indicatorLampEnabled = settingsStore.indicatorLampEnabled.first()
+            indicatorLampStyle = settingsStore.indicatorLampStyle.first()
 
             // カスタムフォント情報の読み込み
             customFonts = settingsStore.getAllCustomFontInfo()
@@ -516,6 +524,9 @@ fun SettingsScreenUpdated(
 
                                 // 自動更新設定を保存
                                 settingsStore.saveAutoUpdateSettings(autoUpdateEnabled, autoUpdateTime)
+
+                                // インジケーターランプ設定を保存
+                                settingsStore.saveIndicatorLampSettings(indicatorLampEnabled, indicatorLampStyle)
 
                                 if (imageSaveLocation.isNotBlank()) {
                                     settingsStore.saveImageSaveLocation(imageSaveLocation)
@@ -1103,6 +1114,59 @@ fun SettingsScreenUpdated(
                     // 説明文
                     Text(
                         text = "指定した時間に小説の更新をチェックします。\n更新があれば通知が表示されます。",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+            }
+            HorizontalDivider()
+
+            // インジケーターランプ設定セクション
+            SettingSection(title = "インジケーターランプ設定") {
+                // インジケーターランプの有効/無効
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("インジケーターランプを表示")
+                    Spacer(modifier = Modifier.weight(1f))
+                    Switch(
+                        checked = indicatorLampEnabled,
+                        onCheckedChange = { indicatorLampEnabled = it }
+                    )
+                }
+
+                // インジケーターランプが有効な場合のみスタイル設定を表示
+                if (indicatorLampEnabled) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        Text(
+                            text = "表示スタイル",
+                            style = MaterialTheme.typography.bodyLarge,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+
+                        RadioButtonOption(
+                            text = "点灯（常時表示）",
+                            selected = indicatorLampStyle == "SOLID",
+                            onClick = { indicatorLampStyle = "SOLID" }
+                        )
+                        RadioButtonOption(
+                            text = "点滅",
+                            selected = indicatorLampStyle == "BLINKING",
+                            onClick = { indicatorLampStyle = "BLINKING" }
+                        )
+                    }
+
+                    // 説明文
+                    Text(
+                        text = "画面左下に更新・取得処理の状態を表示します。\nインジケーターをタップすると詳細を確認できます。",
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -115,6 +115,10 @@ class SettingsStore(private val context: Context) {
         val NOVEL_LIST_SHOW_LONG = booleanPreferencesKey("novel_list_show_long")
         val NOVEL_LIST_SHOW_SHORT = booleanPreferencesKey("novel_list_show_short")
         val NOVEL_LIST_SITE_FILTER = stringPreferencesKey("novel_list_site_filter")
+
+        // インジケーターランプ設定のキー
+        val INDICATOR_LAMP_ENABLED = booleanPreferencesKey("indicator_lamp_enabled")
+        val INDICATOR_LAMP_STYLE = stringPreferencesKey("indicator_lamp_style")
     }
 
     val defaultFontColor = "#000000" // 黒
@@ -160,6 +164,10 @@ class SettingsStore(private val context: Context) {
     val defaultNovelListShowLong = true
     val defaultNovelListShowShort = true
     val defaultNovelListSiteFilter = "ALL"
+
+    // インジケーターランプ設定のデフォルト値
+    val defaultIndicatorLampEnabled = true
+    val defaultIndicatorLampStyle = "SOLID"
 
     val themeMode: Flow<String> = context.dataStore.data
         .catch { exception: Throwable ->
@@ -614,7 +622,33 @@ class SettingsStore(private val context: Context) {
         val preferences = context.dataStore.data.first()
         return preferences[LAST_NOTIFIED_RELEASE] ?: defaultLastNotifiedRelease
     }
-    
+
+    // インジケーターランプ有効/無効の設定値を取得
+    val indicatorLampEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[INDICATOR_LAMP_ENABLED] ?: defaultIndicatorLampEnabled
+        }
+
+    // インジケーターランプスタイルの設定値を取得
+    val indicatorLampStyle: Flow<String> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[INDICATOR_LAMP_STYLE] ?: defaultIndicatorLampStyle
+        }
+
     // 小説リストフィルター設定の取得
     suspend fun getNovelListFilterSettings(): NovelListFilterSettings {
         val preferences = context.dataStore.data.first()
@@ -647,6 +681,14 @@ class SettingsStore(private val context: Context) {
             preferences[NOVEL_LIST_SHOW_LONG] = settings.showLongNovels
             preferences[NOVEL_LIST_SHOW_SHORT] = settings.showShortNovels
             preferences[NOVEL_LIST_SITE_FILTER] = settings.siteFilter
+        }
+    }
+
+    // インジケーターランプ設定を保存するメソッド
+    suspend fun saveIndicatorLampSettings(enabled: Boolean, style: String) {
+        context.dataStore.edit { preferences ->
+            preferences[INDICATOR_LAMP_ENABLED] = enabled
+            preferences[INDICATOR_LAMP_STYLE] = style
         }
     }
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/ProcessingState.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/ProcessingState.kt
@@ -1,0 +1,70 @@
+/*
+ * eightman 2005-2025
+ * Furin-lab All Rights Reserved.
+ * Data class representing the state of a novel processing operation.
+ */
+package com.shunlight_library.novel_reader.data
+
+import androidx.compose.ui.graphics.Color
+
+/**
+ * 処理ステータスタイプ
+ */
+enum class ProcessingStatusType(val displayName: String, val color: Color) {
+    ERROR("エラー", Color.Red),           // エラー: 赤
+    RETRY("再試行", Color.Yellow),        // 再試行: 黄色
+    CHECK("更新確認", Color.Green),       // 更新確認: 緑
+    IDLE("アイドル", Color.Gray),         // アイドル: 灰色
+    FETCHING("取得中", Color.Cyan)        // 取得: 水色
+}
+
+/**
+ * 小説の更新・取得処理の状態を表すデータクラス
+ *
+ * @param id 処理のユニークID（ncode）
+ * @param novelTitle 小説のタイトル
+ * @param progress 進捗率（0.0-1.0）
+ * @param currentEpisode 現在処理中のエピソード番号
+ * @param totalEpisodes 総エピソード数
+ * @param statusType 処理の状態タイプ
+ * @param startTime 処理開始時刻（ミリ秒）
+ * @param errorMessage エラーメッセージ（エラー時のみ）
+ */
+data class ProcessingState(
+    val id: String,
+    val novelTitle: String,
+    val progress: Float = 0.0f,
+    val currentEpisode: Int = 0,
+    val totalEpisodes: Int = 0,
+    val statusType: ProcessingStatusType = ProcessingStatusType.FETCHING,
+    val startTime: Long = System.currentTimeMillis(),
+    val errorMessage: String? = null
+) {
+    companion object {
+        // 後方互換性のための定数
+        @Deprecated("Use ProcessingStatusType.FETCHING instead")
+        const val STATUS_PROCESSING = "取得中"
+        @Deprecated("Use ProcessingStatusType.IDLE or completion logic instead")
+        const val STATUS_COMPLETED = "完了"
+        @Deprecated("Use ProcessingStatusType.ERROR instead")
+        const val STATUS_ERROR = "エラー"
+    }
+
+    /**
+     * 進捗率を計算
+     */
+    fun calculateProgress(): Float {
+        return if (totalEpisodes > 0) {
+            currentEpisode.toFloat() / totalEpisodes.toFloat()
+        } else {
+            0.0f
+        }
+    }
+
+    /**
+     * 経過時間を計算（秒）
+     */
+    fun getElapsedSeconds(): Long {
+        return (System.currentTimeMillis() - startTime) / 1000
+    }
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -22,12 +22,16 @@ import com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity
 import com.shunlight_library.novel_reader.utils.AppLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator
+import com.shunlight_library.novel_reader.data.ProcessingState
 
 class NovelRepository(
     private val episodeDao: EpisodeDao,
@@ -38,6 +42,40 @@ class NovelRepository(
     private val imageCacheDao: ImageCacheDao,
     private val episodeMappingDao: EpisodeMappingDao
 ) {
+    // 処理状態管理（インジケーターランプ用）
+    private val _processingStates = MutableStateFlow<List<ProcessingState>>(emptyList())
+    val processingStates: StateFlow<List<ProcessingState>> = _processingStates.asStateFlow()
+
+    /**
+     * 処理状態を追加
+     */
+    fun addProcessingState(state: ProcessingState) {
+        _processingStates.value = _processingStates.value + state
+    }
+
+    /**
+     * 処理状態を更新
+     */
+    fun updateProcessingState(id: String, updater: (ProcessingState) -> ProcessingState) {
+        _processingStates.value = _processingStates.value.map { state ->
+            if (state.id == id) updater(state) else state
+        }
+    }
+
+    /**
+     * 処理状態を削除
+     */
+    fun removeProcessingState(id: String) {
+        _processingStates.value = _processingStates.value.filter { it.id != id }
+    }
+
+    /**
+     * すべての処理状態をクリア
+     */
+    fun clearAllProcessingStates() {
+        _processingStates.value = emptyList()
+    }
+
     // Novel Description関連メソッド
     val allNovels: Flow<List<NovelDescEntity>> = novelDescDao.getAllNovels()
 
@@ -461,6 +499,15 @@ class NovelRepository(
                 val (adapter, novelId) = com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapterFactory.getAdapterByUrl(url)
                     ?: return@withContext null
 
+                // 処理状態を追加（仮のタイトル）
+                addProcessingState(
+                    ProcessingState(
+                        id = novelId,
+                        novelTitle = "取得中...",
+                        statusType = ProcessingStatusType.FETCHING
+                    )
+                )
+
                 // 登録を開始（制限チェック）
                 when (val result = com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator.beginRegistration(novelId)) {
                     is com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator.RegistrationResult.Success -> {
@@ -490,8 +537,21 @@ class NovelRepository(
                             repository = this@NovelRepository,  // 自身を渡す
                             onProgress = { current, total ->
                                 AppLogger.d("NovelRepository", "[$novelId] エピソード取得中: $current/$total")
+                                // インジケーター状態を更新
+                                updateProcessingState(novelId) { state ->
+                                    state.copy(
+                                        currentEpisode = current,
+                                        totalEpisodes = total,
+                                        progress = if (total > 0) current.toFloat() / total.toFloat() else 0f
+                                    )
+                                }
                             }
                         )
+
+                        // タイトルを更新
+                        updateProcessingState(novelId) { state ->
+                            state.copy(novelTitle = novelDesc.title)
+                        }
 
                         // 小説情報を保存
                         insertNovel(novelDesc)
@@ -505,8 +565,21 @@ class NovelRepository(
                             repository = this@NovelRepository,  // 自身を渡す
                             onProgress = { current, total ->
                                 AppLogger.d("NovelRepository", "[$novelId] エピソード取得中: $current/$total")
+                                // インジケーター状態を更新
+                                updateProcessingState(novelId) { state ->
+                                    state.copy(
+                                        currentEpisode = current,
+                                        totalEpisodes = total,
+                                        progress = if (total > 0) current.toFloat() / total.toFloat() else 0f
+                                    )
+                                }
                             }
                         )
+
+                        // タイトルを更新
+                        updateProcessingState(novelId) { state ->
+                            state.copy(novelTitle = result.novelDesc.title)
+                        }
 
                         // 小説情報を保存
                         insertNovel(result.novelDesc)
@@ -546,9 +619,28 @@ class NovelRepository(
                     }
                 }
 
+                // 処理完了後、少し待ってから状態を削除
+                kotlinx.coroutines.delay(2000)  // 2秒間表示
+                removeProcessingState(novelId)
+
                 novel
             } catch (e: Exception) {
                 AppLogger.e("NovelRepository", "Failed to add novel from URL: $url", e)
+
+                // エラー状態に更新
+                val (adapter, novelId) = com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapterFactory.getAdapterByUrl(url)
+                    ?: return@withContext null
+                updateProcessingState(novelId) { state ->
+                    state.copy(
+                        statusType = ProcessingStatusType.ERROR,
+                        errorMessage = e.message
+                    )
+                }
+
+                // エラー状態を5秒間表示してから削除
+                kotlinx.coroutines.delay(5000)
+                removeProcessingState(novelId)
+
                 throw e  // エラーメッセージを呼び出し元に伝える
             } finally {
                 // 登録セッションを終了

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/components/IndicatorLamp.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/components/IndicatorLamp.kt
@@ -1,0 +1,225 @@
+/*
+ * eightman 2005-2025
+ * Furin-lab All Rights Reserved.
+ * Indicator lamp UI component for displaying processing status.
+ */
+package com.shunlight_library.novel_reader.ui.components
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.shunlight_library.novel_reader.data.ProcessingState
+import com.shunlight_library.novel_reader.data.ProcessingStatusType
+
+/**
+ * インジケーターランプの表示スタイル
+ */
+enum class IndicatorLampStyle {
+    SOLID,    // 点灯（常時表示）
+    BLINKING  // 点滅
+}
+
+/**
+ * インジケーターランプのグループ表示
+ *
+ * @param states 処理状態のリスト
+ * @param style 表示スタイル（点灯/点滅）
+ * @param enabled 表示の有効/無効
+ * @param modifier Modifier
+ */
+@Composable
+fun IndicatorLampGroup(
+    states: List<ProcessingState>,
+    style: IndicatorLampStyle = IndicatorLampStyle.SOLID,
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    if (!enabled || states.isEmpty()) {
+        return
+    }
+
+    var showDetailDialog by remember { mutableStateOf(false) }
+    var selectedState by remember { mutableStateOf<ProcessingState?>(null) }
+
+    // 最大表示数を制限（例：5個まで）
+    val displayStates = states.take(5)
+
+    Row(
+        modifier = modifier
+            .background(Color.Black.copy(alpha = 0.7f), shape = MaterialTheme.shapes.small)
+            .padding(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        displayStates.forEach { state ->
+            IndicatorLamp(
+                state = state,
+                style = style,
+                modifier = Modifier
+                    .size(24.dp)
+                    .clickable {
+                        selectedState = state
+                        showDetailDialog = true
+                    }
+            )
+        }
+
+        // 残りの数を表示
+        if (states.size > 5) {
+            Text(
+                text = "+${states.size - 5}",
+                color = Color.White,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(start = 4.dp)
+            )
+        }
+    }
+
+    // 詳細ダイアログ
+    if (showDetailDialog && selectedState != null) {
+        ProcessingDetailDialog(
+            state = selectedState!!,
+            onDismiss = { showDetailDialog = false }
+        )
+    }
+}
+
+/**
+ * 単一のインジケーターランプ
+ *
+ * @param state 処理状態
+ * @param style 表示スタイル
+ * @param modifier Modifier
+ */
+@Composable
+fun IndicatorLamp(
+    state: ProcessingState,
+    style: IndicatorLampStyle = IndicatorLampStyle.SOLID,
+    modifier: Modifier = Modifier
+) {
+    val color = state.statusType.color
+
+    // 点滅アニメーション
+    val alpha = when (style) {
+        IndicatorLampStyle.SOLID -> 1f
+        IndicatorLampStyle.BLINKING -> {
+            val infiniteTransition = rememberInfiniteTransition(label = "blinking")
+            infiniteTransition.animateFloat(
+                initialValue = 0.3f,
+                targetValue = 1.0f,
+                animationSpec = infiniteRepeatable(
+                    animation = tween(500, easing = FastOutSlowInEasing),
+                    repeatMode = RepeatMode.Reverse
+                ),
+                label = "alpha"
+            ).value
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .clip(CircleShape)
+            .background(color.copy(alpha = alpha))
+    )
+}
+
+/**
+ * 処理詳細ダイアログ
+ *
+ * @param state 処理状態
+ * @param onDismiss ダイアログを閉じる処理
+ */
+@Composable
+fun ProcessingDetailDialog(
+    state: ProcessingState,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text("処理状況")
+        },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // タイトル
+                Row {
+                    Text(
+                        text = "小説: ",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Text(
+                        text = state.novelTitle,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+
+                // 状態
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "状態: ",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Box(
+                        modifier = Modifier
+                            .size(12.dp)
+                            .clip(CircleShape)
+                            .background(state.statusType.color)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = state.statusType.displayName,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+
+                // 進捗
+                if (state.totalEpisodes > 0) {
+                    Column {
+                        Text(
+                            text = "進捗: ${state.currentEpisode} / ${state.totalEpisodes}話",
+                            style = MaterialTheme.typography.bodyMedium
+                        )
+                        LinearProgressIndicator(
+                            progress = state.calculateProgress(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(8.dp)
+                        )
+                    }
+                }
+
+                // 経過時間
+                Text(
+                    text = "経過時間: ${state.getElapsedSeconds()}秒",
+                    style = MaterialTheme.typography.bodySmall
+                )
+
+                // エラーメッセージ
+                if (state.errorMessage != null) {
+                    Text(
+                        text = "エラー: ${state.errorMessage}",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("閉じる")
+            }
+        }
+    )
+}


### PR DESCRIPTION
- 更新・取得処理の状態を視覚的に表示するインジケーターランプを追加
- 複数の処理を同時に表示可能（最大5個、それ以上は件数表示）
- 処理状態に応じた色分け：エラー（赤）、再試行（黄）、更新確認（緑）、アイドル（灰）、取得中（水色）
- インジケーターをタップすると詳細情報（進捗、経過時間、エラーメッセージ等）を表示
- 設定画面で表示ON/OFF、点灯/点滅スタイルを選択可能
- すべての画面で左下に表示

実装内容：
- ProcessingStateデータクラスを作成（処理状態管理）
- NovelRepositoryにStateFlowを追加（複数処理の状態を管理）
- IndicatorLampGroup/IndicatorLampコンポーネントを作成
- MainActivity/NovelReaderAppにインジケーター表示を統合
- SettingsStoreに設定項目を追加
- SettingsScreenに設定UIを追加
- addNovelByUrl等の処理でインジケーター状態を更新

バージョン: 1.5.34 (versionCode: 157)