### PR TITLE
Prevent access to novels during index updates

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 156
-        versionName = "1.5.33"
+        versionCode = 157
+        versionName = "1.5.34"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -69,6 +69,9 @@ fun EpisodeListScreen(
     var episodes by remember { mutableStateOf<List<EpisodeEntity>>(emptyList()) }
     var lastRead by remember { mutableStateOf<LastReadNovelEntity?>(null) }
 
+    // 更新中チェック用の状態変数
+    var isNovelUpdating by remember { mutableStateOf(false) }
+
     // 折りたたみ状態の追加
     var isDescriptionExpanded by remember { mutableStateOf(true) }
 
@@ -128,6 +131,14 @@ fun EpisodeListScreen(
             episodes = episodeList.sortedWith(compareBy {
                 it.episode_no.toIntOrNull() ?: Int.MAX_VALUE
             })
+        }
+    }
+
+    // 更新中状態を定期的にチェック
+    LaunchedEffect(ncode) {
+        while (true) {
+            isNovelUpdating = NovelUpdateCoordinator.isUpdating(ncode)
+            delay(1000) // 1秒ごとにチェック
         }
     }
 
@@ -1430,8 +1441,8 @@ fun EpisodeListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
                             .weight(1f)
-                            .clickable(enabled = lastRead != null) {
-                                if (lastRead != null) {
+                            .clickable(enabled = lastRead != null && !isNovelUpdating) {
+                                if (lastRead != null && !isNovelUpdating) {
                                     onEpisodeClick(ncode, lastRead!!.episode_no.toString())
                                 }
                             }
@@ -1440,12 +1451,12 @@ fun EpisodeListScreen(
                         Icon(
                             Icons.Default.Bookmark,
                             contentDescription = "しおりから読む",
-                            tint = if (lastRead != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            tint = if (lastRead != null && !isNovelUpdating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                         )
                         Text(
                             "しおりから読む",
                             style = MaterialTheme.typography.labelSmall,
-                            color = if (lastRead != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            color = if (lastRead != null && !isNovelUpdating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                         )
                     }
 
@@ -1454,8 +1465,8 @@ fun EpisodeListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
                             .weight(1f)
-                            .clickable(enabled = lastRead != null) {
-                                if (lastRead != null) {
+                            .clickable(enabled = lastRead != null && !isNovelUpdating) {
+                                if (lastRead != null && !isNovelUpdating) {
                                     scope.launch {
                                         try {
                                             repository.deleteLastRead(ncode)
@@ -1473,12 +1484,12 @@ fun EpisodeListScreen(
                         Icon(
                             Icons.Default.BookmarkRemove,
                             contentDescription = "しおりを削除",
-                            tint = if (lastRead != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            tint = if (lastRead != null && !isNovelUpdating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                         )
                         Text(
                             "しおりを削除",
                             style = MaterialTheme.typography.labelSmall,
-                            color = if (lastRead != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                            color = if (lastRead != null && !isNovelUpdating) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
                         )
                     }
 
@@ -1487,14 +1498,24 @@ fun EpisodeListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
                             .weight(1f)
-                            .clickable {
-                                // 更新処理開始
-                                startUpdateProcess()
+                            .clickable(enabled = !isNovelUpdating) {
+                                if (!isNovelUpdating) {
+                                    // 更新処理開始
+                                    startUpdateProcess()
+                                }
                             }
                             .padding(vertical = 8.dp)
                     ) {
-                        Icon(Icons.Default.Refresh, contentDescription = "小説を更新")
-                        Text("小説を更新", style = MaterialTheme.typography.labelSmall)
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = "小説を更新",
+                            tint = if (!isNovelUpdating) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
+                        Text(
+                            "小説を更新",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (!isNovelUpdating) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
                     }
 
                     // タグを編集
@@ -1502,13 +1523,23 @@ fun EpisodeListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
                             .weight(1f)
-                            .clickable {
-                                showTagEditDialog = true
+                            .clickable(enabled = !isNovelUpdating) {
+                                if (!isNovelUpdating) {
+                                    showTagEditDialog = true
+                                }
                             }
                             .padding(vertical = 8.dp)
                     ) {
-                        Icon(Icons.Default.Edit, contentDescription = "タグを編集")
-                        Text("タグを編集", style = MaterialTheme.typography.labelSmall)
+                        Icon(
+                            Icons.Default.Edit,
+                            contentDescription = "タグを編集",
+                            tint = if (!isNovelUpdating) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
+                        Text(
+                            "タグを編集",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (!isNovelUpdating) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
                     }
 
                     // 作者ページを開く
@@ -1516,45 +1547,92 @@ fun EpisodeListScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
                             .weight(1f)
-                            .clickable(enabled = novel != null) {
-                                novel?.let { novelEntity ->
-                                    val userId = novelEntity.userid
-                                    if (userId != null) {
-                                        val url = if (novelEntity.rating == 1) {
-                                            "https://xmypage.syosetu.com/$userId/"
+                            .clickable(enabled = novel != null && !isNovelUpdating) {
+                                if (!isNovelUpdating) {
+                                    novel?.let { novelEntity ->
+                                        val userId = novelEntity.userid
+                                        if (userId != null) {
+                                            val url = if (novelEntity.rating == 1) {
+                                                "https://xmypage.syosetu.com/$userId/"
+                                            } else {
+                                                "https://mypage.syosetu.com/$userId/"
+                                            }
+                                            onAuthorClick(url)
                                         } else {
-                                            "https://mypage.syosetu.com/$userId/"
+                                            Toast.makeText(context, "すでになろうにいません", Toast.LENGTH_SHORT).show()
                                         }
-                                        onAuthorClick(url)
-                                    } else {
-                                        Toast.makeText(context, "すでになろうにいません", Toast.LENGTH_SHORT).show()
                                     }
                                 }
                             }
                             .padding(vertical = 8.dp)
                     ) {
-                        Icon(Icons.Default.Person, contentDescription = "作者")
-                        Text("作者", style = MaterialTheme.typography.labelSmall)
+                        Icon(
+                            Icons.Default.Person,
+                            contentDescription = "作者",
+                            tint = if (novel != null && !isNovelUpdating) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
+                        Text(
+                            "作者",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (novel != null && !isNovelUpdating) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
                     }
                 }
             }
         }
     ) { innerPadding ->
-        // 小説の基本情報表示
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-        ) {
-            // 小説情報のヘッダー部分 - 折りたたみ機能追加
-            novel?.let { novel ->
-                Card(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp)
-                        .clickable { isDescriptionExpanded = !isDescriptionExpanded },
-                    elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        // 更新中の場合はブロック画面を表示
+        if (isNovelUpdating) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(32.dp)
                 ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(64.dp)
+                    )
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Text(
+                        text = "目次を更新中です",
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "しばらくお待ちください",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "エピソードの取得・更新処理が完了するまで\n目次にはアクセスできません",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+                        textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                    )
+                }
+            }
+        } else {
+            // 通常の画面表示（更新中でない場合）
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                // 小説情報のヘッダー部分 - 折りたたみ機能追加
+                novel?.let { novel ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp)
+                            .clickable { isDescriptionExpanded = !isDescriptionExpanded },
+                        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+                    ) {
                     Column(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -1678,6 +1756,8 @@ fun EpisodeListScreen(
                         HorizontalDivider()
                     }
                 }
+            }
+        }
             }
         }
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelListScreen.kt
@@ -877,6 +877,8 @@ fun NovelListScreen(
                     items = displayedNovels,
                     key = { it.novel.ncode }
                 ) { novelWithReadInfo ->
+                    val isUpdating = com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator.isUpdating(novelWithReadInfo.novel.ncode)
+
                     NovelListItem(
                         novel = novelWithReadInfo.novel,
                         unreadCount = novelWithReadInfo.unreadCount,
@@ -887,6 +889,7 @@ fun NovelListScreen(
                         showRating = showRating,
                         showUpdateDate = showUpdateDate,
                         showEpisodeCount = showEpisodeCount,
+                        isUpdating = isUpdating,
                         onClick = { onNovelClick(novelWithReadInfo.novel.ncode) },
                         onFavoriteClick = { isFavorite ->
                             scope.launch {
@@ -919,6 +922,7 @@ fun NovelListItem(
     showRating: Boolean,
     showUpdateDate: Boolean,
     showEpisodeCount: Boolean,
+    isUpdating: Boolean = false,
     onClick: () -> Unit,
     onFavoriteClick: (Boolean) -> Unit
 ) {
@@ -940,11 +944,30 @@ fun NovelListItem(
                     .clickable(onClick = onClick)
             ) {
                 if (showTitle) {
-                    Text(
-                        text = novel.title,
-                        style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = novel.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.weight(1f, fill = false)
+                        )
+                        if (isUpdating) {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(16.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Spacer(modifier = Modifier.width(4.dp))
+                            Text(
+                                text = "更新中",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        }
+                    }
                     Spacer(modifier = Modifier.height(4.dp))
                 }
 


### PR DESCRIPTION
変更内容：
- EpisodeListScreenに更新中チェック機能を追加
  - 更新中の小説には目次を表示せず、「更新中です」というブロック画面を表示
  - 定期的に更新状態をチェックし、完了したら自動的に通常画面を表示
  - 更新中はすべてのボタン（しおりから読む、小説を更新、タグ編集など）を無効化
- NovelListScreenに更新中インジケーターを追加
  - 更新中の小説のタイトル横に小さな進行中アイコンと「更新中」テキストを表示
- NovelUpdateCoordinatorを活用して更新中の小説を追跡
- バージョンを1.5.34（versionCode: 157）に更新

効果：
- エピソード取得・更新処理中にユーザーが目次にアクセスして不整合が発生するのを防止
- 更新中の小説を視覚的に分かりやすく表示
- ユーザーエクスペリエンスの向上