### PR TITLE
Fix null pointer exception in path handling

### DIFF
--- a/Novel_reader/gradle/libs.versions.toml
+++ b/Novel_reader/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.1"
+agp = "8.13.0"
 kotlin = "2.1.20"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
存在しないAndroid Gradle Plugin 8.13.1を有効なバージョン8.13.0に修正。 これによりNullPointerExceptionビルドエラーが解消されます。