### PR TITLE
Fix Room dependency version and bump app version

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 161
-        versionName = "1.6.2"
+        versionCode = 162
+        versionName = "1.6.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -50,7 +50,7 @@ android {
 
 dependencies {
     implementation(libs.androidx.work.runtime.ktx)
-    val room_version = "2.7.1"
+    val room_version = "2.7.0"
     implementation("androidx.room:room-runtime:$room_version")
     implementation("androidx.room:room-ktx:$room_version")
     ksp("androidx.room:room-compiler:$room_version")


### PR DESCRIPTION
## Summary
- correct the Room dependency to a published 2.7.0 release
- bump app versionCode to 162 and versionName to 1.6.3 to reflect the change

## Testing
- Not run (gradle wrapper script missing in repository)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bf26e197c8322858fe12b4fd3f9cc)