### PR TITLE
Align EpisodeEntity indices with migration schema

### DIFF
--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/EpisodeEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/EpisodeEntity.kt
@@ -11,7 +11,13 @@ import androidx.room.Index
 @Entity(
     tableName = "episodes",
     primaryKeys = ["ncode", "episode_no"],
-    indices = [Index(value = ["ncode", "episode_no"], name = "idx_episodes_ncode")]
+    indices = [
+        Index(value = ["ncode", "episode_no"], name = "idx_episodes_ncode"),
+        Index(value = ["is_read"], name = "idx_episodes_is_read"),
+        Index(value = ["is_bookmark"], name = "idx_episodes_is_bookmark"),
+        Index(value = ["ncode", "is_read"], name = "idx_episodes_ncode_read"),
+        Index(value = ["ncode", "is_bookmark"], name = "idx_episodes_ncode_bookmark")
+    ]
 )
 /**
  * 1 話分の情報を表すエンティティ。


### PR DESCRIPTION
## Summary
- add missing episode indices for read/bookmark flags to match migration schema

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c0f2871948322990e5cdc93bd3aad)