### PR TITLE
Fix YAML parsing error in Novel API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 📖 Quick Reference
 
 ### Current State (2025-12-15)
-- **Version**: 1.6.10 (versionCode: 169)
+- **Version**: 1.6.11 (versionCode: 170)
 - **Database**: Version 12 with 7 tables + performance indices
 - **Supported Sites**: Syosetu (なろう小説) + Kakuyomu (カクヨム)
 - **Architecture**: Clean + MVVM + Repository + Adapter Pattern
@@ -636,9 +636,14 @@ val apiUrl = if (isR18) {
     "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua&ncode=$ncode&gzip=5"
 }
 
-// YAMLパース
+// YAMLパース（インデント修正を適用）
+// なろう小説APIから返されるYAMLには、折り畳みスカラー（>）や
+// リテラルスカラー（|）のインデントが不統一な場合があり、
+// SnakeYAMLがパースエラーを起こすことがある。
+// そのため、パース前にfixYamlFoldedScalarIndentation()でインデントを修正する。
+val fixedYaml = fixYamlFoldedScalarIndentation(responseContent)
 val yaml = Yaml()
-val yamlData = yaml.load<List<Map<String, Any>>>(responseContent)
+val yamlData = yaml.load<List<Map<String, Any>>>(fixedYaml)
 val novelData = yamlData[1]  // 0番目はメタデータ、1番目が小説情報
 
 // GZIP解凍判定

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 169
-        versionName = "1.6.10"
+        versionCode = 170
+        versionName = "1.6.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -62,6 +62,85 @@ object NovelApiUtils {
         lastApiAccessTime = System.currentTimeMillis()
     }
 
+    /**
+     * YAMLの折り畳みスカラー（>）とリテラルスカラー（|）のインデント不正を修正する
+     *
+     * なろう小説APIから返されるYAMLには、タイトルや本文の折り畳みスカラーで
+     * インデントが不統一な場合があり、SnakeYAMLがパースエラーを起こすことがある。
+     * この関数は、折り畳みスカラーブロック内の行のインデントを統一する。
+     *
+     * @param yaml 修正対象のYAML文字列
+     * @return インデントを修正したYAML文字列
+     */
+    private fun fixYamlFoldedScalarIndentation(yaml: String): String {
+        val lines = yaml.lines()
+        val result = mutableListOf<String>()
+        var i = 0
+
+        while (i < lines.size) {
+            val line = lines[i]
+
+            // 折り畳みスカラー（>）またはリテラルスカラー（|）を検出
+            // 例: "  title: >", "  story: |"
+            if (line.trimEnd().matches(Regex("^(\\s*)\\w+:\\s*[>|]\\s*$"))) {
+                val keyIndent = line.takeWhile { it == ' ' }.length
+                result.add(line)
+                i++
+
+                // ブロック内の行を収集
+                val blockLines = mutableListOf<String>()
+                while (i < lines.size) {
+                    val blockLine = lines[i]
+
+                    // 空行の場合はそのまま追加
+                    if (blockLine.isBlank()) {
+                        blockLines.add(blockLine)
+                        i++
+                        continue
+                    }
+
+                    val currentIndent = blockLine.takeWhile { it == ' ' }.length
+
+                    // インデントがキーのインデント以下の場合はブロック終了
+                    // または新しいキー（key:形式）が現れた場合もブロック終了
+                    if (currentIndent <= keyIndent || blockLine.trim().matches(Regex("^\\w+:\\s*.*$"))) {
+                        break
+                    }
+
+                    blockLines.add(blockLine)
+                    i++
+                }
+
+                // ブロック内の最小インデントを計算（空行を除く）
+                val minIndent = blockLines
+                    .filter { it.isNotBlank() }
+                    .minOfOrNull { it.takeWhile { c -> c == ' ' }.length }
+                    ?: (keyIndent + 2)
+
+                // ブロック内の全ての行を統一インデントに修正
+                // 基準インデント = キーのインデント + 2スペース
+                val targetIndent = keyIndent + 2
+                val indentAdjustment = targetIndent - minIndent
+
+                for (blockLine in blockLines) {
+                    if (blockLine.isBlank()) {
+                        result.add(blockLine)
+                    } else {
+                        // 元のインデントを削除し、統一インデントを追加
+                        val trimmedLine = blockLine.trimStart()
+                        val adjustedLine = " ".repeat(targetIndent) + trimmedLine
+                        result.add(adjustedLine)
+                    }
+                }
+            } else {
+                result.add(line)
+                i++
+            }
+        }
+
+        return result.joinToString("\n")
+    }
+
     data class NovelApiInfo(
         val generalAllNo: Int,
         val updatedAt: String,
@@ -239,8 +318,11 @@ object NovelApiUtils {
                     //
                     // SnakeYAMLは「|」と「>」の両方を自動処理
                     try {
+                        // YAMLの折り畳みスカラー（>）のインデント不正を修正
+                        val fixedYaml = fixYamlFoldedScalarIndentation(responseContent)
+
                         val yaml = Yaml()
-                        val yamlData = yaml.load<List<Map<String, Any>>>(responseContent)
+                        val yamlData = yaml.load<List<Map<String, Any>>>(fixedYaml)
 
                         Log.d(TAG, "YAML解析成功: ${yamlData?.size ?: 0} 要素")
 
@@ -329,8 +411,11 @@ object NovelApiUtils {
                         content.append(line).append("\n")
                     }
 
+                    // YAMLの折り畳みスカラー（>）のインデント不正を修正
+                    val fixedYaml = fixYamlFoldedScalarIndentation(content.toString())
+
                     val yaml = Yaml()
-                    val yamlData = yaml.load<List<Map<String, Any>>>(content.toString())
+                    val yamlData = yaml.load<List<Map<String, Any>>>(fixedYaml)
 
                     if (yamlData.size >= 2) {
                         val novelData = yamlData[1]


### PR DESCRIPTION
なろう小説APIから返されるYAMLで、title等の折り畳みスカラー（>）の
インデントが不統一な場合にSnakeYAMLがパースエラーを起こす問題を修正。

修正内容:
- fixYamlFoldedScalarIndentation関数を追加し、YAMLパース前に 折り畳みスカラー/リテラルスカラーのインデントを統一
- requestNovelInfo、fetchNovelDetails両関数で適用
- バージョンを1.6.11 (versionCode: 170)に更新
- CLAUDE.mdにYAMLインデント修正処理を追記

エラー例:
title: >
   弱小貴族の異世界奮闘記
  ～うちの領地が大貴族に囲まれてて大変なんです！～

このような不正なインデント（1行目3スペース、2行目2スペース）を
統一インデントに修正することで、パースエラーを回避。