### PR TITLE
漢字（よみがな）をルビとして自動表示するON/OFF機能を追加

### DIFF
--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 184
-        versionName = "1.9.0"
+        versionCode = 185
+        versionName = "1.9.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -77,6 +77,7 @@ fun EpisodeViewScreen(
     var textOrientation by remember { mutableStateOf("Horizontal") }
     var swipeEnabled by remember { mutableStateOf(true) }
     var tapEnabled by remember { mutableStateOf(false) }
+    var autoRubyEnabled by remember { mutableStateOf(true) }
 
     // カスタムフォント情報
     var customFonts by remember { mutableStateOf<List<CustomFontInfo>>(emptyList()) }
@@ -101,6 +102,7 @@ fun EpisodeViewScreen(
             textOrientation = settingsStore.textOrientation.first()
             swipeEnabled = settingsStore.swipeEnabled.first()
             tapEnabled = settingsStore.tapEnabled.first()
+            autoRubyEnabled = settingsStore.autoRubyEnabled.first()
 
             // カスタムフォント情報を読み込む
             customFonts = settingsStore.getAllCustomFontInfo()
@@ -659,6 +661,7 @@ fun EpisodeViewScreen(
                             isCustomFont = isCustomFont,
                             customFontPath = customFontPath,
                             textOrientation = textOrientation,
+                            autoRubyEnabled = autoRubyEnabled,
                             ncode = ncode,
                             episodeNo = episodeNo,
                             savedReadingRate = episode!!.reading_rate,
@@ -739,6 +742,7 @@ fun EnhancedHtmlRubyWebView(
     isCustomFont: Boolean = false,
     customFontPath: String = "",
     textOrientation: String = "Horizontal",
+    autoRubyEnabled: Boolean = true,
     ncode: String,
     episodeNo: String,
     savedReadingRate: Float = 0f,
@@ -750,25 +754,27 @@ fun EnhancedHtmlRubyWebView(
 
     // HTMLを修正する関数
     fun fixRubyTags(html: String): String {
-        // パターン1: <ruby>対象</rb>(ルビ) の修正
+        // パターン1: <ruby>対象</rb>(ルビ) の修正（既存タグの修正なので常に適用）
         var fixed = html.replace("<ruby>([^<]*?)</rb>\\(([^)]*?)\\)".toRegex()) {
             val base = it.groupValues[1]
             val ruby = it.groupValues[2]
             "<ruby>$base<rt>$ruby</rt></ruby>"
         }
 
-        // パターン2: <ruby>対象(ルビ) の修正
+        // パターン2: <ruby>対象(ルビ) の修正（既存タグの修正なので常に適用）
         fixed = fixed.replace("<ruby>([^<(]*?)\\(([^)]*?)\\)".toRegex()) {
             val base = it.groupValues[1]
             val ruby = it.groupValues[2]
             "<ruby>$base<rt>$ruby</rt></ruby>"
         }
 
-        // パターン3: 対象(ルビ) パターンをrubyタグに変換
-        fixed = fixed.replace("([^<>\\s]+?)\\(([^)]+?)\\)".toRegex()) {
-            val base = it.groupValues[1]
-            val ruby = it.groupValues[2]
-            "<ruby>$base<rt>$ruby</rt></ruby>"
+        // パターン3: 漢字（よみがな）→ <ruby> 自動変換（autoRubyEnabled がONのときのみ適用）
+        if (autoRubyEnabled) {
+            fixed = fixed.replace("([^<>\\s]+?)\\(([^)]+?)\\)".toRegex()) {
+                val base = it.groupValues[1]
+                val ruby = it.groupValues[2]
+                "<ruby>$base<rt>$ruby</rt></ruby>"
+            }
         }
 
         return fixed

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
@@ -70,6 +70,7 @@ fun SettingsScreenUpdated(
     var textOrientation by remember { mutableStateOf("Horizontal") }
     var swipeEnabled by remember { mutableStateOf(true) }
     var tapEnabled by remember { mutableStateOf(false) }
+    var autoRubyEnabled by remember { mutableStateOf(true) }
     var selfServerPath by remember { mutableStateOf("") }
     var imageSaveLocation by remember { mutableStateOf("") }
 
@@ -211,6 +212,7 @@ fun SettingsScreenUpdated(
             textOrientation = settingsStore.textOrientation.first()
             swipeEnabled = settingsStore.swipeEnabled.first()
             tapEnabled = settingsStore.tapEnabled.first()
+            autoRubyEnabled = settingsStore.autoRubyEnabled.first()
             selfServerPath = settingsStore.selfServerPath.first()
             imageSaveLocation = settingsStore.imageSaveLocation.first()
 
@@ -515,6 +517,7 @@ fun SettingsScreenUpdated(
                                 // 左右スワイプ設定を保存
                                 settingsStore.saveSwipeEnabled(swipeEnabled)
                                 settingsStore.saveTapEnabled(tapEnabled)
+                                settingsStore.saveAutoRubyEnabled(autoRubyEnabled)
 
                                 // 表示設定を保存
                                 settingsStore.saveDisplaySettings(
@@ -995,6 +998,27 @@ fun SettingsScreenUpdated(
                     Switch(
                         checked = tapEnabled,
                         onCheckedChange = { tapEnabled = it }
+                    )
+                }
+
+                // ルビ自動変換
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("漢字（よみがな）をルビとして表示")
+                        Text(
+                            text = "本文中の「漢字（よみがな）」形式を自動でルビに変換します",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = autoRubyEnabled,
+                        onCheckedChange = { autoRubyEnabled = it }
                     )
                 }
             }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -128,6 +128,9 @@ class SettingsStore(private val context: Context) {
         
         // データベース同期設定のキー
         val DB_SYNC_PRESERVE_EXISTING_EPISODES = booleanPreferencesKey("db_sync_preserve_existing_episodes")
+
+        // ルビ自動変換設定のキー
+        val AUTO_RUBY_ENABLED = booleanPreferencesKey("auto_ruby_enabled")
     }
 
     val defaultFontColor = "#000000" // 黒
@@ -181,6 +184,9 @@ class SettingsStore(private val context: Context) {
     
     // データベース同期設定のデフォルト値
     val defaultDbSyncPreserveExistingEpisodes = true  // デフォルトは既存エピソードを保持
+
+    // ルビ自動変換のデフォルト値
+    val defaultAutoRubyEnabled = true  // デフォルトは有効
 
     val themeMode: Flow<String> = context.dataStore.data
         .catch { exception: Throwable ->
@@ -736,6 +742,26 @@ class SettingsStore(private val context: Context) {
     suspend fun saveDbSyncPreserveExistingEpisodes(preserve: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[DB_SYNC_PRESERVE_EXISTING_EPISODES] = preserve
+        }
+    }
+
+    // ルビ自動変換設定の取得
+    val autoRubyEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[AUTO_RUBY_ENABLED] ?: defaultAutoRubyEnabled
+        }
+
+    // ルビ自動変換設定の保存
+    suspend fun saveAutoRubyEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[AUTO_RUBY_ENABLED] = enabled
         }
     }
     


### PR DESCRIPTION
## 概要

小説本文中の `漢字（よみがな）` 形式をルビ（振り仮名）として自動表示するON/OFF機能を追加しました。

## 変更内容

- **SettingsStore.kt**: `AUTO_RUBY_ENABLED` キー・`autoRubyEnabled` Flow・`saveAutoRubyEnabled()` メソッドを追加。DataStore で永続化。
- **EpisodeViewScreen.kt**: 設定値を読み込み `EnhancedHtmlRubyWebView` に渡す。`fixRubyTags()` のパターン3（平文の `漢字（よみがな）` → `<ruby>` タグ自動変換）を `autoRubyEnabled` で条件分岐。パターン1・2（既存タグの修正）は常に適用。
- **SettingsScreen.kt**: 「漢字（よみがな）をルビとして表示」スイッチを操作設定セクションに追加。
- **build.gradle.kts**: バージョンを 1.9.0 (184) → 1.9.1 (185) に更新。

## テスト計画

- [ ] 設定画面でスイッチのON/OFFが切り替えられることを確認
- [ ] ON時に `漢字（よみがな）` がルビとして描画されることを確認
- [ ] OFF時に通常テキストとして表示されることを確認
- [ ] アプリ再起動後も設定が保持されることを確認
- [ ] 縦書き・横書き両モードで正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)