### PR TITLE
Fix critical bugs in update queue, Kakuyomu registration, and database sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 📖 Quick Reference
 
 ### Current State (2026-06-12)
-- **Version**: 2.0.11 (versionCode: 211)
+- **Version**: 2.0.13 (versionCode: 213)
 - **Database**: Version 16 with 9 tables + performance indices
 - **Supported Sites**: Syosetu (なろう小説) + Kakuyomu (カクヨム)
 - **Architecture**: Clean + MVVM + Repository + Adapter Pattern
@@ -353,6 +353,12 @@ Use `SettingsStore` for persistent configuration with DataStore.
 - Read-status preservation on re-download: 全話再DL（UPDATE_TYPE_DOWNLOAD）時にエピソードを削除せず insertEpisode のマージで is_read/is_bookmark/reading_rate を保持
 - Revision date fix: fetchEpisodeRevisionsFromToc で改稿日時を span[title] 属性から正しく取得（従来は公開日時を誤取得）
 - Error-body prevention: カクヨムエピソード取得失敗時にエラー文字列 ★HTMLページ読み込みエラー を本文として保存しないよう修正
+- Lightweight error scan: 欠落修正スキャンのカクヨム話数確認を fetchUpdateSummary（軽量サマリー）に変更（全話本文DLを排除）
+- Streaming re-download: EpisodeListScreen のカクヨム再DLをストリーミング方式（repository 渡しで1話取得→保存）に変更
+- Gap prevention on partial failure: 一括更新・自動DLで一部失敗時は total_ep を保存済み最大話数に留め、更新キューを残してリトライ可能に（全話成功時のみ確定）
+- DB transactions: deleteNovelWithRelations・insertKakuyomuEpisodesWithMappings・deleteEpisodesByNcode を withTransaction でアトミック化（NovelRepository に RoomDatabase 参照を追加）
+- Schema export: exportSchema=true + room.schemaLocation 設定（v16以降のマイグレーションテスト基盤）
+- Cancel race fix: RegistrationQueueManager.cancelQueue でジョブを cancelAndJoin してから一時データ削除（孤児 temp_episodes 防止）
 
 ### Performance Optimizations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 📖 Quick Reference
 
-### Current State (2026-05-15)
-- **Version**: 2.0.5 (versionCode: 205)
+### Current State (2026-06-11)
+- **Version**: 2.0.6 (versionCode: 206)
 - **Database**: Version 16 with 9 tables + performance indices
 - **Supported Sites**: Syosetu (なろう小説) + Kakuyomu (カクヨム)
 - **Architecture**: Clean + MVVM + Repository + Adapter Pattern
@@ -347,6 +347,7 @@ Use `SettingsStore` for persistent configuration with DataStore.
 - Error fix options: 欠落修正にオプションダイアログ追加（期間・短編除外・完結除外・媒体・挿絵エラー検知）
 - Download status screen: ダウンロード状況画面にフィルターチップと一括削除ボタンを追加
 - ToC recovery: カクヨムDL中断時の復帰策 - episode_mappingテーブルからエピソードスタブを再構築するバナーをEpisodeListScreenに追加（エラー修正で本文を再取得）
+- Auto ruby conversion toggle: 「漢字（よみがな）」形式を自動でルビ変換するON/OFF設定（設定画面・DataStore永続化、横書きWebView表示に適用。既存の壊れた<ruby>タグ修正は常時適用）
 
 ### Performance Optimizations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 📖 Quick Reference
 
-### Current State (2026-06-11)
-- **Version**: 2.0.6 (versionCode: 206)
+### Current State (2026-06-12)
+- **Version**: 2.0.11 (versionCode: 211)
 - **Database**: Version 16 with 9 tables + performance indices
 - **Supported Sites**: Syosetu (なろう小説) + Kakuyomu (カクヨム)
 - **Architecture**: Clean + MVVM + Repository + Adapter Pattern
@@ -348,6 +348,11 @@ Use `SettingsStore` for persistent configuration with DataStore.
 - Download status screen: ダウンロード状況画面にフィルターチップと一括削除ボタンを追加
 - ToC recovery: カクヨムDL中断時の復帰策 - episode_mappingテーブルからエピソードスタブを再構築するバナーをEpisodeListScreenに追加（エラー修正で本文を再取得）
 - Auto ruby conversion toggle: 「漢字（よみがな）」形式を自動でルビ変換するON/OFF設定（設定画面・DataStore永続化、横書きWebView表示に適用。既存の壊れた<ruby>タグ修正は常時適用）
+- Vertical mode ruby parity: applyRubyFixes() をトップレベル関数として抽出。縦書きモード（VjapVerticalTextView）にも破損タグ修復と autoRubyEnabled 変換を適用
+- WebView resource cleanup: AndroidView の onRelease コールバックで stopLoading/destroy を呼び出しネイティブリソースリークを防止（EpisodeViewScreen・WebViewScreen）
+- Read-status preservation on re-download: 全話再DL（UPDATE_TYPE_DOWNLOAD）時にエピソードを削除せず insertEpisode のマージで is_read/is_bookmark/reading_rate を保持
+- Revision date fix: fetchEpisodeRevisionsFromToc で改稿日時を span[title] 属性から正しく取得（従来は公開日時を誤取得）
+- Error-body prevention: カクヨムエピソード取得失敗時にエラー文字列 ★HTMLページ読み込みエラー を本文として保存しないよう修正
 
 ### Performance Optimizations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 📖 Quick Reference
 
 ### Current State (2026-06-12)
-- **Version**: 2.0.13 (versionCode: 213)
+- **Version**: 2.0.14 (versionCode: 214)
 - **Database**: Version 16 with 9 tables + performance indices
 - **Supported Sites**: Syosetu (なろう小説) + Kakuyomu (カクヨム)
 - **Architecture**: Clean + MVVM + Repository + Adapter Pattern
@@ -359,6 +359,7 @@ Use `SettingsStore` for persistent configuration with DataStore.
 - DB transactions: deleteNovelWithRelations・insertKakuyomuEpisodesWithMappings・deleteEpisodesByNcode を withTransaction でアトミック化（NovelRepository に RoomDatabase 参照を追加）
 - Schema export: exportSchema=true + room.schemaLocation 設定（v16以降のマイグレーションテスト基盤）
 - Cancel race fix: RegistrationQueueManager.cancelQueue でジョブを cancelAndJoin してから一時データ削除（孤児 temp_episodes 防止）
+- Episode list lightweight loading: EpisodeMeta DTO（本文なし射影 + body_empty フラグ）と getEpisodeMetasByNcode により、EpisodeListScreen が全話の本文をメモリにロードせず一覧表示（1000話超でも軽量）
 
 ### Performance Optimizations
 

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 212
-        versionName = "2.0.12"
+        versionCode = 213
+        versionName = "2.0.13"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -48,7 +48,16 @@ android {
         compose = true
         buildConfig = true
     }
+
+    // Roomスキーマのエクスポート先（MigrationTestで使用）
+    sourceSets {
+        getByName("androidTest").assets.srcDir("$projectDir/schemas")
+    }
 //    buildToolsVersion = "35.0.0"
+}
+
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 dependencies {

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 209
-        versionName = "2.0.9"
+        versionCode = 210
+        versionName = "2.0.10"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 211
-        versionName = "2.0.11"
+        versionCode = 212
+        versionName = "2.0.12"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 208
-        versionName = "2.0.8"
+        versionCode = 209
+        versionName = "2.0.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 206
-        versionName = "2.0.6"
+        versionCode = 207
+        versionName = "2.0.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 213
-        versionName = "2.0.13"
+        versionCode = 214
+        versionName = "2.0.14"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 205
-        versionName = "2.0.5"
+        versionCode = 206
+        versionName = "2.0.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 210
-        versionName = "2.0.10"
+        versionCode = 211
+        versionName = "2.0.11"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 207
-        versionName = "2.0.7"
+        versionCode = 208
+        versionName = "2.0.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/src/androidTest/java/com/shunlight_library/novel_reader/data/repository/NovelRepositoryTest.kt
+++ b/Novel_reader/app/src/androidTest/java/com/shunlight_library/novel_reader/data/repository/NovelRepositoryTest.kt
@@ -50,7 +50,10 @@ class NovelRepositoryTest {
             updateQueueDao = database.updateQueueDao(),
             urlEntityDao = database.urlEntityDao(),
             imageCacheDao = database.imageCacheDao(),
-            episodeMappingDao = database.episodeMappingDao()
+            episodeMappingDao = database.episodeMappingDao(),
+            registrationQueueDao = database.registrationQueueDao(),
+            tempEpisodeDao = database.tempEpisodeDao(),
+            database = database
         )
     }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -66,7 +66,7 @@ fun EpisodeListScreen(
 
     // 状態変数
     var novel by remember { mutableStateOf<NovelDescEntity?>(null) }
-    var episodes by remember { mutableStateOf<List<EpisodeEntity>>(emptyList()) }
+    var episodes by remember { mutableStateOf<List<com.shunlight_library.novel_reader.data.entity.EpisodeMeta>>(emptyList()) }
     var lastRead by remember { mutableStateOf<LastReadNovelEntity?>(null) }
 
     // 更新中チェック用の状態変数
@@ -147,8 +147,8 @@ fun EpisodeListScreen(
     }
 
     LaunchedEffect(ncode) {
-        // エピソード一覧の取得（Flow型なのでLaunchedEffectで直接collect可能）
-        repository.getEpisodesByNcode(ncode).collect { episodeList ->
+        // エピソード一覧の取得（本文を含まない軽量メタデータ — 大量話数でもメモリ効率良好）
+        repository.getEpisodeMetasByNcode(ncode).collect { episodeList ->
             // エピソードリストを数値順にソート
             episodes = episodeList.sortedWith(compareBy {
                 it.episode_no.toIntOrNull() ?: Int.MAX_VALUE
@@ -796,13 +796,13 @@ fun EpisodeListScreen(
 
         scope.launch {
             try {
-                // エピソードを取得
+                // エピソードを取得（本文なしメタデータ — エラー判定は body_empty フラグで行う）
                 novel?.let {
-                    val episodesList = repository.getEpisodesByNcode(it.ncode).first()
+                    val episodesList = repository.getEpisodeMetasByNcode(it.ncode).first()
 
                     // エラーのあるエピソードを見つける
                     val errorEpisodes = episodesList.filter { episode ->
-                        episode.body.isEmpty() || episode.e_title.isEmpty()
+                        episode.body_empty == 1 || episode.e_title.isEmpty()
                     }
 
                     val generalAllNoValue: Int
@@ -1069,9 +1069,8 @@ fun EpisodeListScreen(
                         return@launch
                     }
 
-                    // 小説のtotal_epを更新
-                    val updatedEpisodes = repository.getEpisodesByNcode(targetNovel.ncode).first()
-                    val maxEpisodeNo = updatedEpisodes.mapNotNull { episode -> episode.episode_no.toIntOrNull() }.maxOrNull() ?: 0
+                    // 小説のtotal_epを更新（最大話数のみ取得 — 全話本文ロードを回避）
+                    val maxEpisodeNo = repository.getMainMaxEpisodeNo(targetNovel.ncode) ?: 0
 
                     if (maxEpisodeNo > targetNovel.total_ep) {
                         val updatedNovel = targetNovel.copy(total_ep = maxEpisodeNo)
@@ -1912,7 +1911,7 @@ fun EpisodeListScreen(
 
 @Composable
 fun EpisodeItem(
-    episode: EpisodeEntity,
+    episode: com.shunlight_library.novel_reader.data.entity.EpisodeMeta,
     onClick: () -> Unit
 ) {
     Row(

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -645,14 +645,21 @@ fun EpisodeListScreen(
                     val isKakuyomu = com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator.isKakuyomuNcode(ncode)
                     
                     if (isKakuyomu) {
-                        // カクヨムの場合は一括取得（マッピング情報付き）
+                        // カクヨムの場合はストリーミング方式（1話取得→保存）で再取得
                         updateMessage = "カクヨムからエピソードを取得中..."
                         val adapter = com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter()
                         val workId = com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator.extractKakuyomuWorkId(ncode)
 
-                        // マッピング情報を含めて取得（改善版メソッド使用）
-                        val result = adapter.fetchNovelWithEpisodesIncludingMappings(workId)
-                        val episodes = result.episodes
+                        // repository を渡して1話ずつ保存（全話メモリ蓄積を回避）
+                        val result = adapter.fetchNovelWithEpisodesIncludingMappings(
+                            novelId = workId,
+                            repository = repository,
+                            onProgress = { current, total ->
+                                updateProgress = if (total > 0) current.toFloat() / total else 0f
+                                updateMessage = "エピソードを取得中... ($current/$total)"
+                                successCount = current
+                            }
+                        )
                         val mappings = result.episodeMappings
 
                         if (session.isCancelled()) {
@@ -660,17 +667,24 @@ fun EpisodeListScreen(
                             return@launch
                         }
 
-                        // エピソードとマッピングを一括保存（改善版メソッド使用）
-                        updateMessage = "エピソードとマッピングを保存中... (${episodes.size}話)"
-                        withContext(Dispatchers.IO) {
-                            repository.insertKakuyomuEpisodesWithMappings(episodes, mappings)
+                        // マッピング情報を保存（エピソード本体は取得中に1話ずつ保存済み）
+                        if (mappings.isNotEmpty()) {
+                            withContext(Dispatchers.IO) {
+                                val mappingEntities = mappings.map { (episodeNo, kakuyomuId) ->
+                                    com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity(
+                                        ncode = ncode,
+                                        episode_no = episodeNo,
+                                        kakuyomu_episode_id = kakuyomuId
+                                    )
+                                }
+                                repository.insertEpisodeMappings(mappingEntities)
+                            }
                         }
 
-                        successCount = episodes.size
                         updateProgress = 1.0f
-                        updateMessage = "保存完了: ${episodes.size}話"
+                        updateMessage = "保存完了: ${successCount}話"
 
-                        android.util.Log.d("EpisodeListScreen", "カクヨムエピソード一括保存完了: ${successCount}話, マッピング: ${mappings.size}件")
+                        android.util.Log.d("EpisodeListScreen", "カクヨムエピソード保存完了: ${successCount}話, マッピング: ${mappings.size}件")
                     } else {
                         // 小説家になろうの場合は逐次取得
                         // エピソード番号のリスト

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -78,6 +78,7 @@ fun EpisodeViewScreen(
     var textOrientation by remember { mutableStateOf("Horizontal") }
     var swipeEnabled by remember { mutableStateOf(true) }
     var tapEnabled by remember { mutableStateOf(false) }
+    var autoRubyEnabled by remember { mutableStateOf(true) }
 
     // カスタムフォント情報
     var customFonts by remember { mutableStateOf<List<CustomFontInfo>>(emptyList()) }
@@ -105,6 +106,7 @@ fun EpisodeViewScreen(
             textOrientation = settingsStore.textOrientation.first()
             swipeEnabled = settingsStore.swipeEnabled.first()
             tapEnabled = settingsStore.tapEnabled.first()
+            autoRubyEnabled = settingsStore.autoRubyEnabled.first()
 
             // カスタムフォント情報を読み込む
             customFonts = settingsStore.getAllCustomFontInfo()
@@ -675,6 +677,7 @@ fun EpisodeViewScreen(
                             isCustomFont = isCustomFont,
                             customFontPath = customFontPath,
                             textOrientation = textOrientation,
+                            autoRubyEnabled = autoRubyEnabled,
                             ncode = ncode,
                             episodeNo = episodeNo,
                             savedReadingRate = episode!!.reading_rate,
@@ -751,6 +754,7 @@ fun EnhancedHtmlRubyWebView(
     isCustomFont: Boolean = false,
     customFontPath: String = "",
     textOrientation: String = "Horizontal",
+    autoRubyEnabled: Boolean = true,
     ncode: String,
     episodeNo: String,
     savedReadingRate: Float = 0f,
@@ -762,25 +766,27 @@ fun EnhancedHtmlRubyWebView(
 
     // HTMLを修正する関数
     fun fixRubyTags(html: String): String {
-        // パターン1: <ruby>対象</rb>(ルビ) の修正
+        // パターン1: <ruby>対象</rb>(ルビ) の修正（既存タグの修正なので常に適用）
         var fixed = html.replace("<ruby>([^<]*?)</rb>\\(([^)]*?)\\)".toRegex()) {
             val base = it.groupValues[1]
             val ruby = it.groupValues[2]
             "<ruby>$base<rt>$ruby</rt></ruby>"
         }
 
-        // パターン2: <ruby>対象(ルビ) の修正
+        // パターン2: <ruby>対象(ルビ) の修正（既存タグの修正なので常に適用）
         fixed = fixed.replace("<ruby>([^<(]*?)\\(([^)]*?)\\)".toRegex()) {
             val base = it.groupValues[1]
             val ruby = it.groupValues[2]
             "<ruby>$base<rt>$ruby</rt></ruby>"
         }
 
-        // パターン3: 対象(ルビ) パターンをrubyタグに変換
-        fixed = fixed.replace("([^<>\\s]+?)\\(([^)]+?)\\)".toRegex()) {
-            val base = it.groupValues[1]
-            val ruby = it.groupValues[2]
-            "<ruby>$base<rt>$ruby</rt></ruby>"
+        // パターン3: 漢字（よみがな）→ <ruby> 自動変換（autoRubyEnabled がONのときのみ適用）
+        if (autoRubyEnabled) {
+            fixed = fixed.replace("([^<>\\s]+?)\\(([^)]+?)\\)".toRegex()) {
+                val base = it.groupValues[1]
+                val ruby = it.groupValues[2]
+                "<ruby>$base<rt>$ruby</rt></ruby>"
+            }
         }
 
         return fixed

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -654,7 +654,7 @@ fun EpisodeViewScreen(
                         val bgColor = if (useDefaultBackground) "#FFFFFF" else backgroundColor
                         key(ncode, episodeNo) {
                             VjapVerticalTextView(
-                                htmlContent = episode!!.body,
+                                htmlContent = applyRubyFixes(episode!!.body, autoRubyEnabled),
                                 episodeTitle = episode!!.e_title ?: "第${episodeNo}話",
                                 fontSize = fontSize,
                                 fontColor = fontColor,
@@ -701,6 +701,23 @@ fun EpisodeViewScreen(
         }
     }
 
+}
+
+// Applies broken ruby-tag repair and optional auto-ruby conversion.
+// Extracted from EnhancedHtmlRubyWebView so the vertical path can use the same logic.
+private fun applyRubyFixes(html: String, autoRubyEnabled: Boolean): String {
+    var fixed = html.replace("<ruby>([^<]*?)</rb>\\(([^)]*?)\\)".toRegex()) {
+        "<ruby>${it.groupValues[1]}<rt>${it.groupValues[2]}</rt></ruby>"
+    }
+    fixed = fixed.replace("<ruby>([^<(]*?)\\(([^)]*?)\\)".toRegex()) {
+        "<ruby>${it.groupValues[1]}<rt>${it.groupValues[2]}</rt></ruby>"
+    }
+    if (autoRubyEnabled) {
+        fixed = fixed.replace("([^<>\\s]+?)\\(([^)]+?)\\)".toRegex()) {
+            "<ruby>${it.groupValues[1]}<rt>${it.groupValues[2]}</rt></ruby>"
+        }
+    }
+    return fixed
 }
 
 // Add these utility functions
@@ -764,33 +781,8 @@ fun EnhancedHtmlRubyWebView(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
-    // HTMLを修正する関数
-    fun fixRubyTags(html: String): String {
-        // パターン1: <ruby>対象</rb>(ルビ) の修正（既存タグの修正なので常に適用）
-        var fixed = html.replace("<ruby>([^<]*?)</rb>\\(([^)]*?)\\)".toRegex()) {
-            val base = it.groupValues[1]
-            val ruby = it.groupValues[2]
-            "<ruby>$base<rt>$ruby</rt></ruby>"
-        }
-
-        // パターン2: <ruby>対象(ルビ) の修正（既存タグの修正なので常に適用）
-        fixed = fixed.replace("<ruby>([^<(]*?)\\(([^)]*?)\\)".toRegex()) {
-            val base = it.groupValues[1]
-            val ruby = it.groupValues[2]
-            "<ruby>$base<rt>$ruby</rt></ruby>"
-        }
-
-        // パターン3: 漢字（よみがな）→ <ruby> 自動変換（autoRubyEnabled がONのときのみ適用）
-        if (autoRubyEnabled) {
-            fixed = fixed.replace("([^<>\\s]+?)\\(([^)]+?)\\)".toRegex()) {
-                val base = it.groupValues[1]
-                val ruby = it.groupValues[2]
-                "<ruby>$base<rt>$ruby</rt></ruby>"
-            }
-        }
-
-        return fixed
-    }
+    // HTMLを修正する関数（共通実装は applyRubyFixes に委譲）
+    fun fixRubyTags(html: String): String = applyRubyFixes(html, autoRubyEnabled)
 
     // 背景色の設定（デフォルトの場合はテーマの色）
     val bgColor = backgroundColor ?: "#FFFFFF"
@@ -1009,6 +1001,10 @@ fun EnhancedHtmlRubyWebView(
                 WebSettings.LayoutAlgorithm.TEXT_AUTOSIZING
             }
             view.loadDataWithBaseURL(null, formattedHtml, "text/html", "UTF-8", null)
+        },
+        onRelease = { view ->
+            view.stopLoading()
+            view.destroy()
         },
         modifier = modifier.fillMaxSize()
     )

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -47,7 +47,11 @@ import com.shunlight_library.novel_reader.data.NotificationType
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Build
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import android.Manifest
+import android.content.pm.PackageManager
 import com.shunlight_library.novel_reader.metadata.MetadataUpdateManager
 import com.shunlight_library.novel_reader.metadata.MetadataUpdateResult
 import com.shunlight_library.novel_reader.ui.components.IndicatorLampGroup
@@ -61,6 +65,10 @@ import kotlinx.coroutines.flow.first
 class MainActivity : ComponentActivity() {
     private lateinit var navigationManager: NavigationManager
     private lateinit var backPressedCallback: OnBackPressedCallback
+
+    // Android 13+ の通知権限要求
+    private val requestNotificationPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* 結果は無視 */ }
     
     // R18ダイアログの表示状態
     private val _showR18Dialog = mutableStateOf(false)
@@ -81,6 +89,14 @@ class MainActivity : ComponentActivity() {
 
         // ナビゲーションマネージャーの作成
         navigationManager = NavigationManager()
+
+        // Android 13+ で通知権限をリクエスト（POST_NOTIFICATIONS）
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            requestNotificationPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
 
         // OnBackPressedCallback を設定
         backPressedCallback = object : OnBackPressedCallback(true) {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/MainActivity.kt
@@ -343,7 +343,7 @@ fun NovelReaderApp(
 
         is Screen.NovelList -> {
             NovelListScreen(
-                onBack = { navigationManager.navigateTo(Screen.Main) },
+                onBack = { navigationManager.navigateBack() },
                 onNovelClick = { ncode ->
                     navigationManager.navigateTo(Screen.EpisodeList(ncode, currentScreen))
                 },
@@ -355,7 +355,7 @@ fun NovelReaderApp(
         EpisodeListScreen(
             ncode = currentScreen.ncode,
             onBack = {
-                navigationManager.navigateTo(Screen.NovelList())
+                navigationManager.navigateBack()
             },
             onEpisodeClick = { ncode, episodeNo ->
                 navigationManager.navigateTo(Screen.EpisodeView(ncode, episodeNo, currentScreen))

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/NovelReaderApplication.kt
@@ -31,7 +31,8 @@ class NovelReaderApplication : Application() {
             database.imageCacheDao(),
             database.episodeMappingDao(),
             database.registrationQueueDao(),
-            database.tempEpisodeDao()
+            database.tempEpisodeDao(),
+            database
         )
     }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsScreen.kt
@@ -76,6 +76,7 @@ fun SettingsScreenUpdated(
     var textOrientation by remember { mutableStateOf("Horizontal") }
     var swipeEnabled by remember { mutableStateOf(true) }
     var tapEnabled by remember { mutableStateOf(false) }
+    var autoRubyEnabled by remember { mutableStateOf(true) }
     var selfServerPath by remember { mutableStateOf("") }
     var imageSaveLocation by remember { mutableStateOf("") }
 
@@ -220,6 +221,7 @@ fun SettingsScreenUpdated(
             textOrientation = settingsStore.textOrientation.first()
             swipeEnabled = settingsStore.swipeEnabled.first()
             tapEnabled = settingsStore.tapEnabled.first()
+            autoRubyEnabled = settingsStore.autoRubyEnabled.first()
             selfServerPath = settingsStore.selfServerPath.first()
             imageSaveLocation = settingsStore.imageSaveLocation.first()
 
@@ -527,6 +529,7 @@ fun SettingsScreenUpdated(
                                 // 左右スワイプ設定を保存
                                 settingsStore.saveSwipeEnabled(swipeEnabled)
                                 settingsStore.saveTapEnabled(tapEnabled)
+                                settingsStore.saveAutoRubyEnabled(autoRubyEnabled)
 
                                 // 表示設定を保存
                                 settingsStore.saveDisplaySettings(
@@ -1033,6 +1036,27 @@ fun SettingsScreenUpdated(
                     Switch(
                         checked = tapEnabled,
                         onCheckedChange = { tapEnabled = it }
+                    )
+                }
+
+                // ルビ自動変換
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp, horizontal = 16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("漢字（よみがな）をルビとして表示")
+                        Text(
+                            text = "本文中の「漢字（よみがな）」形式を自動でルビに変換します",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                    Switch(
+                        checked = autoRubyEnabled,
+                        onCheckedChange = { autoRubyEnabled = it }
                     )
                 }
             }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/SettingsStore.kt
@@ -142,6 +142,9 @@ class SettingsStore(private val context: Context) {
         
         // データベース同期設定のキー
         val DB_SYNC_PRESERVE_EXISTING_EPISODES = booleanPreferencesKey("db_sync_preserve_existing_episodes")
+
+        // ルビ自動変換設定のキー
+        val AUTO_RUBY_ENABLED = booleanPreferencesKey("auto_ruby_enabled")
     }
 
     val defaultFontColor = "#000000" // 黒
@@ -195,6 +198,9 @@ class SettingsStore(private val context: Context) {
     
     // データベース同期設定のデフォルト値
     val defaultDbSyncPreserveExistingEpisodes = true  // デフォルトは既存エピソードを保持
+
+    // ルビ自動変換のデフォルト値
+    val defaultAutoRubyEnabled = true  // デフォルトは有効
 
     val themeMode: Flow<String> = context.dataStore.data
         .catch { exception: Throwable ->
@@ -788,6 +794,26 @@ class SettingsStore(private val context: Context) {
     suspend fun saveDbSyncPreserveExistingEpisodes(preserve: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[DB_SYNC_PRESERVE_EXISTING_EPISODES] = preserve
+        }
+    }
+
+    // ルビ自動変換設定の取得
+    val autoRubyEnabled: Flow<Boolean> = context.dataStore.data
+        .catch { exception: Throwable ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }
+        .map { preferences: Preferences ->
+            preferences[AUTO_RUBY_ENABLED] ?: defaultAutoRubyEnabled
+        }
+
+    // ルビ自動変換設定の保存
+    suspend fun saveAutoRubyEnabled(enabled: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[AUTO_RUBY_ENABLED] = enabled
         }
     }
     

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -858,7 +858,9 @@ fun UpdateInfoScreen(
                                                                 val adapter = NovelSiteAdapterFactory.getAdapter(NovelSiteAdapter.SITE_TYPE_KAKUYOMU) as com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
                                                                 val workId = PseudoNcodeGenerator.extractKakuyomuWorkId(novel.ncode)
 
-                                                                // カクヨムのエピソード一覧再取得フラグ（小説ごとに1回のみ再取得）
+                                                                // 全話を事前に1回だけ取得してMapに（ループ内での都度全話ロードを防ぐ）
+                                                                var episodeMap = repository.getEpisodesByNcode(novel.ncode).first()
+                                                                    .associateBy { it.episode_no }
                                                                 var mappingRefreshed = false
 
                                                                 for (episodeNo in episodesList) {
@@ -871,9 +873,7 @@ fun UpdateInfoScreen(
                                                                     syncMessage = "「${novel.title}」の第${episodeNoStr}話を取得中..."
 
                                                                     try {
-                                                                        // データベースから既存のエピソード情報を取得（メタデータ取得時に保存されている）
-                                                                        var existingEpisodes = repository.getEpisodesByNcode(novel.ncode).first()
-                                                                        var existingEpisode = existingEpisodes.find { it.episode_no == episodeNoStr }
+                                                                        var existingEpisode = episodeMap[episodeNoStr]
 
                                                                         // エピソード情報が見つからない場合、mapping情報が古い可能性があるため再取得
                                                                         if (existingEpisode == null && !mappingRefreshed) {
@@ -908,9 +908,10 @@ fun UpdateInfoScreen(
                                                                                 // 再取得フラグを立てる（小説ごとに1回のみ）
                                                                                 mappingRefreshed = true
 
-                                                                                // 再度エピソード情報を取得
-                                                                                existingEpisodes = repository.getEpisodesByNcode(novel.ncode).first()
-                                                                                existingEpisode = existingEpisodes.find { it.episode_no == episodeNoStr }
+                                                                                // Mapを再構築して以降のループで使用
+                                                                                episodeMap = repository.getEpisodesByNcode(novel.ncode).first()
+                                                                                    .associateBy { it.episode_no }
+                                                                                existingEpisode = episodeMap[episodeNoStr]
 
                                                                                 syncMessage = "「${novel.title}」の第${episodeNoStr}話を取得中..."
                                                                             } catch (refreshError: Exception) {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.shunlight_library.novel_reader.api.NovelApiUtils
+import com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapterFactory
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
@@ -286,10 +287,12 @@ fun UpdateInfoScreen(
 
                                     val generalAllNoValue: Int
                                     if (novel.site_type == NovelSiteAdapter.SITE_TYPE_KAKUYOMU) {
-                                        val adapter = NovelSiteAdapterFactory.getAdapter(NovelSiteAdapter.SITE_TYPE_KAKUYOMU)
+                                        // 軽量サマリー取得（全話本文DLせずに話数とメタデータのみ確認）
+                                        val adapter = NovelSiteAdapterFactory.getAdapter(NovelSiteAdapter.SITE_TYPE_KAKUYOMU) as KakuyomuAdapter
                                         val workId = PseudoNcodeGenerator.extractKakuyomuWorkId(novel.ncode)
-                                        val (updatedNovelDesc, allEpisodes) = adapter.fetchNovelWithEpisodes(workId)
-                                        generalAllNoValue = allEpisodes.size
+                                        val summary = adapter.fetchUpdateSummary(workId)
+                                        generalAllNoValue = summary.latestEpisodeCount
+                                        val updatedNovelDesc = summary.novelDesc
                                         val updatedNovel = novel.copy(
                                             general_all_no = generalAllNoValue,
                                             updated_at = updatedNovelDesc.updated_at,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/WebViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/WebViewScreen.kt
@@ -455,6 +455,10 @@ fun WebViewScreen(
                         currentLoadingUrl = url
                         currentUrl = url
                     }
+                },
+                onRelease = { view ->
+                    view.stopLoading()
+                    view.destroy()
                 }
             )
         }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -965,12 +965,19 @@ object NovelApiUtils {
                         val title = element.select("a.p-eplist__subtitle").text()
 
                         // 更新日時を取得
+                        // 改稿済みエピソードは <span title="yyyy/MM/dd HH:mm 改稿"> で最終改稿日時を保持する。
+                        // .text() は公開日時を返すため、span[title] を優先して読む。
                         val updateElement = element.select("div.p-eplist__update")
-                        var updateTimeStr = updateElement.text()
-                            .replace("（改）", "")
-                            .replace("（改稿）", "")
-                            .replace(Regex("\\(\\s*<u>改</u>\\s*\\)"), "")  // HTMLタグ付き改稿マークを除去
-                            .trim()
+                        val revisionSpan = updateElement.select("span[title]").firstOrNull()
+                        val updateTimeStr = if (revisionSpan != null) {
+                            // title 例: "2024/01/02 15:00 改稿"
+                            revisionSpan.attr("title").replace("改稿", "").trim()
+                        } else {
+                            updateElement.text()
+                                .replace("（改）", "")
+                                .replace("（改稿）", "")
+                                .trim()
+                        }
 
                         // 日時フォーマットを変換: "2024/01/01 12:00" -> "2024-01-01 12:00:00"
                         val updateTime = try {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -67,7 +67,7 @@ class KakuyomuAdapter : NovelSiteAdapter {
     companion object {
         private const val BASE_URL = "https://kakuyomu.jp"
         private const val RATE_LIMIT_DELAY_MS = 500L  // 0.5秒（スクレイピング時の推奨間隔）
-        private var lastAccessTime = 0L
+        @Volatile private var lastAccessTime = 0L
 
         // PC版User-Agentを使用（モバイル版では目次が省略される可能性があるため）
         private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -803,6 +803,9 @@ class KakuyomuAdapter : NovelSiteAdapter {
      * @param workDoc 呼び出し元で取得済みの作品ページDocument（再フェッチ防止）
      */
     private suspend fun parseEpisodeList(workId: String, pseudoNcode: String, workDoc: Document): List<EpisodeEntity> {
+        // 各呼び出し開始時にキャッシュをリセットして別作品の残留を防ぐ
+        cachedMappings = emptyMap()
+
         // 呼び出し元の取得済みdocから最初のエピソードリンクを抽出（重複フェッチ防止）
         val firstEpisodeLink = workDoc.select("a.widget-toc-episode-episodeTitle").firstOrNull()?.attr("href")
             ?: workDoc.select("a.WorkTocSection_link__ocg9K").firstOrNull()?.attr("href")
@@ -923,13 +926,12 @@ class KakuyomuAdapter : NovelSiteAdapter {
                 getCurrentDate()
             }
 
-            // episode_noには実際のカクヨムエピソードIDを格納
-            // これによりURLの生成が正確になる
+            val sequentialNo = index + 1
             episodes.add(
                 EpisodeEntity(
                     ncode = pseudoNcode,
-                    episode_no = episodeId,  // カクヨムの実際のエピソードIDを使用
-                    body = "",  // TOCページには本文がないため空（後でfetchEpisodeContentで取得）
+                    episode_no = sequentialNo.toString(),  // 連番（他メソッドと統一）
+                    body = "",
                     e_title = episodeTitle,
                     update_time = publishedDate,
                     is_read = 0,
@@ -939,7 +941,26 @@ class KakuyomuAdapter : NovelSiteAdapter {
             )
         }
 
-        AppLogger.d("KakuyomuAdapter", "エピソード一覧パース完了 (HTML): ${episodes.size}話")
+        // 方法3 でも cachedMappings を構築（連番→カクヨムID）
+        val fallbackMappings = mutableMapOf<Int, String>()
+        var idx = 0
+        val allElements = if (doc.select("a.WorkTocSection_link__ocg9K").isNotEmpty())
+            doc.select("a.WorkTocSection_link__ocg9K")
+        else
+            doc.select("ol.widget-toc-items li.widget-toc-episode")
+        allElements.forEach { elem ->
+            val link = elem.attr("href").ifEmpty { elem.select("a").attr("href") }
+            val eid = link.substringAfterLast("/")
+            if (eid.isNotEmpty()) {
+                idx++
+                fallbackMappings[idx] = eid
+            }
+        }
+        if (fallbackMappings.isNotEmpty()) {
+            cachedMappings = fallbackMappings
+        }
+
+        AppLogger.d("KakuyomuAdapter", "エピソード一覧パース完了 (HTML方法3): ${episodes.size}話")
         return episodes
     }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/EpisodeDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/EpisodeDao.kt
@@ -7,12 +7,24 @@ package com.shunlight_library.novel_reader.data.dao
 
 import androidx.room.*
 import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
+import com.shunlight_library.novel_reader.data.entity.EpisodeMeta
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface EpisodeDao {
     @Query("SELECT * FROM episodes WHERE ncode = :ncode ORDER BY episode_no")
     fun getEpisodesByNcode(ncode: String): Flow<List<EpisodeEntity>>
+
+    /**
+     * 一覧表示用の軽量メタデータを取得（本文を含まない）
+     * 1000話超の作品でも本文をメモリにロードせずに一覧表示できる
+     */
+    @Query(
+        "SELECT ncode, episode_no, e_title, update_time, is_read, is_bookmark, reading_rate, " +
+                "CASE WHEN body = '' THEN 1 ELSE 0 END AS body_empty " +
+                "FROM episodes WHERE ncode = :ncode ORDER BY episode_no"
+    )
+    fun getEpisodeMetasByNcode(ncode: String): Flow<List<EpisodeMeta>>
 
     @Query("SELECT * FROM episodes WHERE ncode = :ncode AND episode_no = :episodeNo")
     suspend fun getEpisode(ncode: String, episodeNo: String): EpisodeEntity?

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/RegistrationQueueDao.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/dao/RegistrationQueueDao.kt
@@ -60,6 +60,12 @@ interface RegistrationQueueDao {
     @Query("UPDATE registration_queue SET title = :title, total_episodes = :totalEpisodes WHERE id = :id")
     suspend fun updateNovelInfo(id: Long, title: String, totalEpisodes: Int)
 
+    @Query("UPDATE registration_queue SET total_episodes = :totalEpisodes WHERE id = :id")
+    suspend fun updateTotalEpisodes(id: Long, totalEpisodes: Int)
+
     @Query("UPDATE registration_queue SET current_episode = :currentEpisode WHERE id = :id")
     suspend fun updateProgress(id: Long, currentEpisode: Int)
+
+    @Query("UPDATE registration_queue SET status = 0, error_message = NULL WHERE status = 1")
+    suspend fun resetStuckProcessingToP(): Int
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/database/NovelDatabase.kt
@@ -302,7 +302,7 @@ val MIGRATION_15_16 = object : Migration(15, 16) {
         TempEpisodeEntity::class
     ],
     version = 16,
-    exportSchema = false
+    exportSchema = true
 )
 abstract class NovelDatabase : RoomDatabase() {
     abstract fun episodeDao(): EpisodeDao

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/EpisodeMeta.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/EpisodeMeta.kt
@@ -1,0 +1,32 @@
+/*
+ * eightman 2005-2025
+ * Furin-lab All Rights Reserved.
+ * エピソード一覧表示用の軽量メタデータ（本文を含まない）。
+ */
+package com.shunlight_library.novel_reader.data.entity
+
+/**
+ * エピソード一覧画面用の軽量DTO。
+ *
+ * EpisodeEntity から本文（body）を除いた射影。
+ * 1000話超の作品でも一覧表示時に本文をメモリへロードしないために使用する。
+ *
+ * @property ncode このエピソードが属する小説の N コード
+ * @property episode_no エピソード番号（1 からの連番）
+ * @property e_title エピソードタイトル
+ * @property update_time 最終更新日時（yyyy-MM-dd HH:mm:ss）
+ * @property is_read 既読フラグ (0=未読, 1=既読)
+ * @property is_bookmark しおり登録フラグ (0=未登録, 1=登録済み)
+ * @property reading_rate 読了率（0.0～1.0）
+ * @property body_empty 本文が空かどうか (0=本文あり, 1=空) — エラー検出用
+ */
+data class EpisodeMeta(
+    val ncode: String,
+    val episode_no: String,
+    val e_title: String,
+    val update_time: String,
+    val is_read: Int = 0,
+    val is_bookmark: Int = 0,
+    val reading_rate: Float = 0f,
+    val body_empty: Int = 0
+)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/ImageCacheEntity.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/entity/ImageCacheEntity.kt
@@ -1,6 +1,7 @@
 package com.shunlight_library.novel_reader.data.entity
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 /**
@@ -8,7 +9,10 @@ import androidx.room.PrimaryKey
  * 画像の内容ハッシュをファイル名とし、
  * 元URLと保存先パス、MIMEタイプを保持する。
  */
-@Entity(tableName = "image_cache")
+@Entity(
+    tableName = "image_cache",
+    indices = [Index(value = ["hash"], name = "idx_image_cache_hash")]
+)
 data class ImageCacheEntity(
     @PrimaryKey val hash: String,
     val original_url: String,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -163,27 +163,33 @@ class NovelRepository(
             if (episodes.isEmpty()) {
                 return@withContext
             }
-            
+
             if (preserveExisting) {
-                val ncode = episodes.first().ncode
-                val existingEpisodes = episodeDao.getEpisodesByNcode(ncode).first()
-                val existingMap = existingEpisodes.associateBy { it.episode_no }
-                
-                val mergedEpisodes = episodes.map { newEpisode ->
-                    val existing = existingMap[newEpisode.episode_no]
-                    if (existing != null) {
-                        newEpisode.copy(
-                            body = if (newEpisode.body.isEmpty() && existing.body.isNotEmpty()) existing.body else newEpisode.body,
-                            is_read = existing.is_read,
-                            is_bookmark = existing.is_bookmark,
-                            reading_rate = existing.reading_rate
-                        )
-                    } else {
-                        newEpisode
+                // ncode 単位でグループ化して処理（複数 ncode をまたぐバッチでも既読情報が正しく保持される）
+                val grouped = episodes.groupBy { it.ncode }
+                val mergedAll = mutableListOf<EpisodeEntity>()
+
+                for ((ncode, group) in grouped) {
+                    val existingEpisodes = episodeDao.getEpisodesByNcode(ncode).first()
+                    val existingMap = existingEpisodes.associateBy { it.episode_no }
+
+                    val merged = group.map { newEpisode ->
+                        val existing = existingMap[newEpisode.episode_no]
+                        if (existing != null) {
+                            newEpisode.copy(
+                                body = if (newEpisode.body.isEmpty() && existing.body.isNotEmpty()) existing.body else newEpisode.body,
+                                is_read = existing.is_read,
+                                is_bookmark = existing.is_bookmark,
+                                reading_rate = existing.reading_rate
+                            )
+                        } else {
+                            newEpisode
+                        }
                     }
+                    mergedAll.addAll(merged)
                 }
-                
-                episodeDao.insertEpisodes(mergedEpisodes)
+
+                episodeDao.insertEpisodes(mergedAll)
             } else {
                 episodeDao.insertEpisodes(episodes)
             }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -1037,6 +1037,14 @@ class NovelRepository(
         registrationQueueDao.updateNovelInfo(id, title, totalEpisodes)
     }
 
+    suspend fun updateRegistrationQueueTotalEpisodes(id: Long, totalEpisodes: Int) {
+        registrationQueueDao.updateTotalEpisodes(id, totalEpisodes)
+    }
+
+    suspend fun resetStuckProcessingQueues(): Int {
+        return registrationQueueDao.resetStuckProcessingToP()
+    }
+
     suspend fun cancelRegistrationQueue(id: Long) {
         val queue = registrationQueueDao.getById(id)
         if (queue != null && queue.status == RegistrationQueueEntity.STATUS_PENDING) {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -24,6 +24,7 @@ import com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity
 import com.shunlight_library.novel_reader.data.entity.RegistrationQueueEntity
 import com.shunlight_library.novel_reader.data.entity.TempEpisodeEntity
 import com.shunlight_library.novel_reader.utils.AppLogger
+import androidx.room.withTransaction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -47,8 +48,21 @@ class NovelRepository(
     private val imageCacheDao: ImageCacheDao,
     private val episodeMappingDao: EpisodeMappingDao,
     private val registrationQueueDao: RegistrationQueueDao,
-    private val tempEpisodeDao: TempEpisodeDao
+    private val tempEpisodeDao: TempEpisodeDao,
+    private val database: androidx.room.RoomDatabase? = null
 ) {
+    /**
+     * 複数テーブルへの書き込みをアトミックに実行する。
+     * database が未指定の場合（一部テスト）はトランザクションなしで実行する。
+     */
+    private suspend fun <T> runInTransaction(block: suspend () -> T): T {
+        return if (database != null) {
+            database.withTransaction { block() }
+        } else {
+            block()
+        }
+    }
+
     // 処理状態管理（インジケーターランプ用）
     private val _processingStates = MutableStateFlow<List<ProcessingState>>(emptyList())
     val processingStates: StateFlow<List<ProcessingState>> = _processingStates.asStateFlow()
@@ -286,11 +300,7 @@ class NovelRepository(
                 }
             }
 
-            // マージしたエピソードを保存
-            episodeDao.insertEpisodes(mergedEpisodes)
-            android.util.Log.d("NovelRepository", "カクヨムエピソード保存: ${mergedEpisodes.size}件 (ncode=$ncode, 既存: ${existingMap.size}件, 新規: ${mergedEpisodes.size - existingMap.size}件)")
-
-            // マッピング情報を保存
+            // マッピング情報を構築
             val mappingEntities = mappings.map { (episodeNo, kakuyomuId) ->
                 EpisodeMappingEntity(
                     ncode = ncode,
@@ -299,19 +309,23 @@ class NovelRepository(
                 )
             }
 
-            if (mappingEntities.isNotEmpty()) {
-                episodeMappingDao.insertMappings(mappingEntities)
-                android.util.Log.d("NovelRepository", "カクヨムマッピング保存: ${mappingEntities.size}件 (ncode=$ncode)")
-            } else {
-                android.util.Log.w("NovelRepository", "マッピング情報が空です (ncode=$ncode)")
+            // エピソードとマッピングをアトミックに保存（片方だけ保存される不整合を防止）
+            runInTransaction {
+                episodeDao.insertEpisodes(mergedEpisodes)
+                if (mappingEntities.isNotEmpty()) {
+                    episodeMappingDao.insertMappings(mappingEntities)
+                }
             }
+            android.util.Log.d("NovelRepository", "カクヨムエピソード保存: ${mergedEpisodes.size}件, マッピング: ${mappingEntities.size}件 (ncode=$ncode)")
         }
     }
 
     suspend fun deleteEpisodesByNcode(ncode: String) {
-        episodeDao.deleteEpisodesByNcode(ncode)
-        // カクヨムのマッピングも削除
-        episodeMappingDao.deleteMappingsByNcode(ncode)
+        runInTransaction {
+            episodeDao.deleteEpisodesByNcode(ncode)
+            // カクヨムのマッピングも削除
+            episodeMappingDao.deleteMappingsByNcode(ncode)
+        }
     }
 
     // EpisodeMapping関連メソッド（カクヨム用）
@@ -388,13 +402,17 @@ class NovelRepository(
             throw IllegalStateException("進行中の更新を停止できませんでした: ${novel.ncode}")
         }
         withContext(Dispatchers.IO) {
-            deleteEpisodesByNcode(novel.ncode)
-            lastReadNovelDao.getLastReadByNcode(novel.ncode)?.let {
-                lastReadNovelDao.deleteLastRead(it)
+            // 複数テーブルにまたがる削除をアトミックに実行（中断時の不整合防止）
+            runInTransaction {
+                episodeDao.deleteEpisodesByNcode(novel.ncode)
+                episodeMappingDao.deleteMappingsByNcode(novel.ncode)
+                lastReadNovelDao.getLastReadByNcode(novel.ncode)?.let {
+                    lastReadNovelDao.deleteLastRead(it)
+                }
+                updateQueueDao.deleteUpdateQueueByNcode(novel.ncode)
+                urlEntityDao.deleteURLByNcode(novel.ncode)
+                novelDescDao.deleteNovel(novel)
             }
-            updateQueueDao.deleteUpdateQueueByNcode(novel.ncode)
-            urlEntityDao.deleteURLByNcode(novel.ncode)
-            novelDescDao.deleteNovel(novel)
         }
     }
     // NovelRepository.kt に追加

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/repository/NovelRepository.kt
@@ -129,6 +129,11 @@ class NovelRepository(
         return episodeDao.getEpisodesByNcode(ncode)
     }
 
+    /** 一覧表示用の軽量メタデータ（本文なし）を取得 */
+    fun getEpisodeMetasByNcode(ncode: String): Flow<List<com.shunlight_library.novel_reader.data.entity.EpisodeMeta>> {
+        return episodeDao.getEpisodeMetasByNcode(ncode)
+    }
+
     suspend fun getEpisodesByNcodeList(ncode: String): List<EpisodeEntity> {
         return episodeDao.getEpisodesByNcodeList(ncode)
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/DatabaseSyncManager.kt
@@ -239,9 +239,9 @@ class DatabaseSyncManager(private val context: Context) {
                 // URLEntityも作成
                 val isR18 = novel.rating == 1
                 val apiUrl = if (isR18) {
-                    "https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua&ncode=${novel.ncode}&gzip=5&json"
+                    "https://api.syosetu.com/novel18api/api/?of=t-w-ga-s-ua&ncode=${novel.ncode}&gzip=5"
                 } else {
-                    "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua&ncode=${novel.ncode}&gzip=5&json"
+                    "https://api.syosetu.com/novelapi/api/?of=t-w-ga-s-ua&ncode=${novel.ncode}&gzip=5"
                 }
                 val webUrl = if (isR18) {
                     "https://novel18.syosetu.com/${novel.ncode}/"

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/ImprovedDatabaseSyncManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/sync/ImprovedDatabaseSyncManager.kt
@@ -140,8 +140,8 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
                     progress = 0.2f
                 ))
 
-                // 必要なテーブルの存在確認
-                val requiredTables = listOf("novels_descs", "episodes", "rast_read_novel")
+                // 必要なテーブルの存在確認（reading history は命名揺れを許容）
+                val requiredTables = listOf("novels_descs", "episodes")
                 for (table in requiredTables) {
                     if (!sqliteHelper.isTableExists(db, table)) {
                         // 存在するテーブル一覧を取得してログ出力
@@ -325,17 +325,44 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
             val columnLength = getColumnIndexSafely(cursor, "length")
             val columnUpdatedAt = getColumnIndexSafely(cursor, "updated_at")
             val columnRegisteredAt = getColumnIndexSafely(cursor, "registered_at")
+            // 外部DBにこれらカラムがあれば読む（v8+以降のエクスポート）
+            val columnIsFavorite = getColumnIndexSafely(cursor, "is_favorite")
+            val columnSiteType = getColumnIndexSafely(cursor, "site_type")
+            val columnSubSite = getColumnIndexSafely(cursor, "sub_site")
+            val columnEndFlag = getColumnIndexSafely(cursor, "end_flag")
 
             val batchSize = 50
             val novels = mutableListOf<NovelDescEntity>()
 
             // データの読み取りとバッチ処理
             while (cursor.moveToNext()) {
+                val ncode = getStringSafely(cursor, columnNcode)
                 val userid = getStringSafely(cursor, columnUserid)
                 val noveltype = getIntSafely(cursor, columnNoveltype, -1)
                 val length = getIntSafely(cursor, columnLength, -1)
+
+                // 既存の内部レコードを取得し、外部DBに無いフィールドを保持する
+                val existing = repository.getNovelByNcode(ncode)
+
+                val isFavorite = when {
+                    columnIsFavorite != null -> getIntSafely(cursor, columnIsFavorite)
+                    else -> existing?.is_favorite ?: 0
+                }
+                val siteType = when {
+                    columnSiteType != null -> getIntSafely(cursor, columnSiteType, 1)
+                    else -> existing?.site_type ?: 1
+                }
+                val subSite = when {
+                    columnSubSite != null -> getIntSafely(cursor, columnSubSite, 0)
+                    else -> existing?.sub_site ?: 0
+                }
+                val endFlag = when {
+                    columnEndFlag != null -> getIntSafely(cursor, columnEndFlag, 0)
+                    else -> existing?.end_flag ?: 0
+                }
+
                 val novel = NovelDescEntity(
-                    ncode = getStringSafely(cursor, columnNcode),
+                    ncode = ncode,
                     title = getStringSafely(cursor, columnTitle),
                     author = getStringSafely(cursor, columnAuthor),
                     Synopsis = getStringSafely(cursor, columnSynopsis),
@@ -352,7 +379,11 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
                     updated_at = getStringSafely(cursor, columnUpdatedAt,
                         DatabaseSyncUtils.getCurrentDateTimeString()),
                     registered_at = getStringSafely(cursor, columnRegisteredAt,
-                        DatabaseSyncUtils.getCurrentDateTimeString())
+                        DatabaseSyncUtils.getCurrentDateTimeString()),
+                    is_favorite = isFavorite,
+                    site_type = siteType,
+                    sub_site = subSite,
+                    end_flag = endFlag
                 )
 
                 novels.add(novel)
@@ -562,9 +593,16 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
         var count = 0
         var totalCount = 0
 
+        // テーブル名の揺れに対応（旧アプリは "rast_read_novel" の誤記名で作られたDBが存在する）
+        val lastReadTable = when {
+            sqliteHelper.isTableExists(externalDb, "last_read_novel") -> "last_read_novel"
+            sqliteHelper.isTableExists(externalDb, "rast_read_novel") -> "rast_read_novel"
+            else -> return 0
+        }
+
         try {
             // 総レコード数を取得
-            totalCount = sqliteHelper.getTableCount(externalDb, "last_read_novel")
+            totalCount = sqliteHelper.getTableCount(externalDb, lastReadTable)
 
             // 進捗初期化の報告
             updateProgress(syncCallback, SyncProgress(
@@ -577,7 +615,7 @@ class ImprovedDatabaseSyncManager(private val context: Context) {
 
             // 外部DBから最終読書記録を取得
             cursor = externalDb.query(
-                "last_read_novel",
+                lastReadTable,
                 null,
                 null,
                 null,

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
@@ -13,6 +13,7 @@ import com.shunlight_library.novel_reader.data.entity.EpisodeEntity
 import com.shunlight_library.novel_reader.data.entity.RegistrationQueueEntity
 import com.shunlight_library.novel_reader.data.entity.TempEpisodeEntity
 import com.shunlight_library.novel_reader.utils.AppLogger
+import com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -97,8 +98,15 @@ object RegistrationQueueManager {
         return withContext(Dispatchers.IO) {
             try {
                 // URLからアダプターと小説IDを取得
-                val (adapter, novelId) = NovelSiteAdapterFactory.getAdapterByUrl(url)
+                val (adapter, rawNovelId) = NovelSiteAdapterFactory.getAdapterByUrl(url)
                     ?: throw Exception("サポート対象外のURLです: $url")
+
+                // カクヨムは疑似Ncodeに変換（workId数値列のままだと temp→main のマージが失敗する）
+                val novelId = if (adapter.getSiteType() == NovelSiteAdapter.SITE_TYPE_KAKUYOMU) {
+                    PseudoNcodeGenerator.generateKakuyomuNcode(rawNovelId)
+                } else {
+                    rawNovelId
+                }
 
                 // 既に登録済みの場合
                 val existingNovel = repository.getNovelByNcode(novelId)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -167,15 +168,17 @@ object RegistrationQueueManager {
      */
     suspend fun cancelQueue(id: Long) {
         withContext(Dispatchers.IO) {
+            // 先に処理中のジョブを停止して完了を待つ
+            // （削除後にジョブが temp_episodes へ書き込み、孤児データが残る競合を防ぐ）
+            processingQueues[id]?.cancelAndJoin()
+            processingQueues.remove(id)
+            pausedQueueIds.remove(id)
+
             val queue = repository.getRegistrationQueueById(id)
             if (queue != null) {
                 // 一時エピソードも削除
                 repository.deleteTempEpisodesByNcode(queue.ncode)
             }
-            // 処理中のジョブがあればキャンセル
-            processingQueues[id]?.cancel()
-            processingQueues.remove(id)
-            pausedQueueIds.remove(id)
             // キューを削除
             repository.deleteRegistrationQueue(id)
             AppLogger.d(TAG, "キューを削除: id=$id")

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
@@ -67,6 +67,14 @@ object RegistrationQueueManager {
     fun startMonitoring() {
         AppLogger.d(TAG, "キュー監視を開始")
         monitoringJob = scope.launch {
+            // 起動時に STATUS_PROCESSING 残骸をリセット（プロセス強制終了で残ったもの）
+            try {
+                val reset = repository.resetStuckProcessingQueues()
+                if (reset > 0) AppLogger.w(TAG, "STATUS_PROCESSING の残骸 ${reset} 件を PENDING にリセットしました")
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "PROCESSING リセット失敗", e)
+            }
+
             while (true) {
                 try {
                     processNextQueue()
@@ -582,7 +590,8 @@ object RegistrationQueueManager {
     private suspend fun updateQueueProgress(id: Long, currentEpisode: Int, totalEpisodes: Int) {
         repository.updateRegistrationQueueProgress(id, currentEpisode)
         if (totalEpisodes > 0) {
-            repository.updateRegistrationQueueNovelInfo(id, "", totalEpisodes)
+            // title は変更しない（空文字で上書きするとDL状況画面が空欄になる）
+            repository.updateRegistrationQueueTotalEpisodes(id, totalEpisodes)
         }
     }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
@@ -1353,15 +1353,29 @@ class UpdateService : Service() {
                     successCount += successForNovel
                     failCount += failForNovel
 
-                    // Update novel info
-                    val updatedNovel = novel.copy(
-                        total_ep = endEpisode,
-                        general_all_no = endEpisode
-                    )
-                    repository.updateNovel(updatedNovel)
-
-                    // Remove from update queue
-                    repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                    if (failForNovel == 0) {
+                        // 全話成功: total_ep を確定しキューから削除
+                        val updatedNovel = novel.copy(
+                            total_ep = endEpisode,
+                            general_all_no = endEpisode
+                        )
+                        repository.updateNovel(updatedNovel)
+                        repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                    } else {
+                        // 一部失敗: 実際に保存された最大話数を total_ep に反映し、
+                        // 末尾まで届いていない場合はキューを残して次回リトライ可能にする
+                        val maxSavedEp = repository.getEpisodesByNcode(novel.ncode).first()
+                            .mapNotNull { it.episode_no.toIntOrNull() }.maxOrNull() ?: novel.total_ep
+                        repository.updateNovel(novel.copy(
+                            total_ep = maxSavedEp,
+                            general_all_no = endEpisode
+                        ))
+                        if (maxSavedEp >= endEpisode) {
+                            // 末尾まで保存済み（途中の欠番はエラー修正で再取得可能）
+                            repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                        }
+                        Log.w(TAG, "一括更新で${failForNovel}件失敗: ${queueItem.ncode} (保存済み最大話数: $maxSavedEp)")
+                    }
                 }
 
                 val message = if (skippedNovels.isEmpty()) {

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
@@ -114,8 +114,9 @@ class UpdateService : Service() {
 
                 if (!isRunning) {
                     isRunning = true
-                    currentNcode = ncode
-                    updateType = requestedUpdateType
+
+                    // キューに追加してから処理を開始（空キューで即完了するバグを防ぐ）
+                    operationQueue.add(UpdateOperation(ncode, requestedUpdateType))
 
                     // 通知の作成
                     val notification = createNotification("更新処理を開始しています...")
@@ -132,7 +133,7 @@ class UpdateService : Service() {
                         startForeground(NOTIFICATION_ID, notification)
                     }
 
-                    // 最初のオペレーションを開始
+                    // キューから最初のオペレーションを取り出して実行
                     processNextOperation()
                 } else {
                     // 実行中の場合もキューに追加（次に処理される）

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
@@ -20,8 +20,10 @@ import com.shunlight_library.novel_reader.MainActivity
 import com.shunlight_library.novel_reader.NovelReaderApplication
 import com.shunlight_library.novel_reader.R
 import com.shunlight_library.novel_reader.api.NovelApiUtils
+import com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapterFactory
+import com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity
 import com.shunlight_library.novel_reader.data.entity.UpdateQueueEntity
 import com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator
 import kotlinx.coroutines.*
@@ -1240,47 +1242,98 @@ class UpdateService : Service() {
                     var cancelledForNovel = false
 
                     try {
-                        for (episodeNo in episodesToDownload) {
-                            if (!isRunning) {
-                                updateComplete(false, "更新処理が中断されました")
-                                return@launch
+                        if (novel.site_type == NovelSiteAdapter.SITE_TYPE_KAKUYOMU) {
+                            // カクヨム: mapping を更新してから本文取得
+                            val kakuyomuAdapter = NovelSiteAdapterFactory.getAdapter(
+                                NovelSiteAdapter.SITE_TYPE_KAKUYOMU
+                            ) as KakuyomuAdapter
+                            val workId = PseudoNcodeGenerator.extractKakuyomuWorkId(novel.ncode)
+
+                            val (_, episodeList) = kakuyomuAdapter.fetchNovelMetadataWithEpisodeList(workId)
+                            val mappings = kakuyomuAdapter.getCachedMappings()
+
+                            if (mappings.isNotEmpty()) {
+                                val mappingEntities = mappings.map { (epNo, kakuyomuId) ->
+                                    EpisodeMappingEntity(novel.ncode, epNo, kakuyomuId)
+                                }
+                                repository.insertEpisodeMappings(mappingEntities)
                             }
 
-                            if (session.isCancelled()) {
-                                cancelledForNovel = true
-                                break
+                            val episodeTitles = episodeList.associate {
+                                it.episode_no.toIntOrNull() to (it.e_title ?: "第${it.episode_no}話")
                             }
 
-                            val episode = NovelApiUtils.fetchEpisodeWithRetry(
-                                novel.ncode,
-                                episodeNo.toString(),
-                                novel.rating == 1,
-                                novel.noveltype
-                            )
+                            for (episodeNo in episodesToDownload) {
+                                if (!isRunning) { updateComplete(false, "更新処理が中断されました"); return@launch }
+                                if (session.isCancelled()) { cancelledForNovel = true; break }
 
-                            if (episode != null) {
-                                repository.insertEpisode(episode)
-                                successForNovel++
-                            } else {
-                                failForNovel++
+                                val kakuyomuId = mappings[episodeNo]
+                                if (kakuyomuId == null) { failForNovel++; processedForNovel++; processedEpisodes++; continue }
+
+                                val body = kakuyomuAdapter.fetchEpisodeContent(workId, kakuyomuId)
+                                if (body.isNotEmpty() && !body.startsWith("★HTMLページ読み込みエラー")) {
+                                    val ep = com.shunlight_library.novel_reader.data.entity.EpisodeEntity(
+                                        ncode = novel.ncode,
+                                        episode_no = episodeNo.toString(),
+                                        e_title = episodeTitles[episodeNo] ?: "第${episodeNo}話",
+                                        body = body,
+                                        update_time = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
+                                    )
+                                    repository.insertEpisode(ep)
+                                    successForNovel++
+                                } else {
+                                    failForNovel++
+                                }
+                                processedForNovel++
+                                processedEpisodes++
+
+                                val denom = maxOf(totalEpisodes, processedEpisodes, 1)
+                                updateProgress(0.3f + (0.7f * processedEpisodes.toFloat() / denom), "エピソードをダウンロード中... ($processedEpisodes/$denom)")
+                                delay(500)
                             }
+                        } else {
+                            // なろう（Syosetu）
+                            for (episodeNo in episodesToDownload) {
+                                if (!isRunning) {
+                                    updateComplete(false, "更新処理が中断されました")
+                                    return@launch
+                                }
 
-                            processedForNovel++
-                            processedEpisodes++
+                                if (session.isCancelled()) {
+                                    cancelledForNovel = true
+                                    break
+                                }
 
-                            val denominator = if (totalEpisodes <= 0) {
-                                if (processedEpisodes == 0) 1 else processedEpisodes
-                            } else {
-                                maxOf(totalEpisodes, processedEpisodes)
+                                val episode = NovelApiUtils.fetchEpisodeWithRetry(
+                                    novel.ncode,
+                                    episodeNo.toString(),
+                                    novel.rating == 1,
+                                    novel.noveltype
+                                )
+
+                                if (episode != null) {
+                                    repository.insertEpisode(episode)
+                                    successForNovel++
+                                } else {
+                                    failForNovel++
+                                }
+
+                                processedForNovel++
+                                processedEpisodes++
+
+                                val denominator = if (totalEpisodes <= 0) {
+                                    if (processedEpisodes == 0) 1 else processedEpisodes
+                                } else {
+                                    maxOf(totalEpisodes, processedEpisodes)
+                                }
+                                val fraction = processedEpisodes.toFloat() / denominator.toFloat()
+                                updateProgress(
+                                    0.3f + (0.7f * fraction),
+                                    "エピソードをダウンロード中... ($processedEpisodes/$denominator)"
+                                )
+
+                                delay(200)
                             }
-                            val fraction = processedEpisodes.toFloat() / denominator.toFloat()
-                            updateProgress(
-                                0.3f + (0.7f * fraction),
-                                "エピソードをダウンロード中... ($processedEpisodes/$denominator)"
-                            )
-
-                            // Avoid server overload
-                            delay(200)
                         }
                     } finally {
                         NovelUpdateCoordinator.finishUpdate(session)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/service/UpdateService.kt
@@ -618,8 +618,7 @@ class UpdateService : Service() {
                         return@launch
                     }
 
-                    // 既存エピソードとマッピングを全削除（再取得なので最初からやり直す）
-                    repository.deleteEpisodesByNcode(ncode)
+                    // 既存エピソードは削除しない。insertEpisode が is_read/is_bookmark/reading_rate を保持してマージする。
 
                     // 全エピソードを取得対象とする
                     val episodesToDownload = episodeListWithoutBody
@@ -667,16 +666,16 @@ class UpdateService : Service() {
 
                             if (episodeBody.isEmpty() || episodeBody.startsWith("★HTMLページ読み込みエラー")) {
                                 Log.e(TAG, "Failed to fetch episode body after ${maxRetries} retries: ${episode.episode_no}")
+                                // エラー文字列で既存の本文を上書きしない
+                            } else {
+                                // 正常取得できた場合のみ保存
+                                val episodeWithBody = episode.copy(body = episodeBody)
+                                repository.insertEpisode(episodeWithBody)
+                                successCount++
                             }
-
-                            // 本文を含めてエピソードを保存（1話ずつ）
-                            val episodeWithBody = episode.copy(body = episodeBody)
-                            repository.insertEpisode(episodeWithBody)
-                            successCount++
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to fetch episode ${episode.episode_no}: ${e.message}")
-                            // エラーでも処理を継続（本文なしで保存）
-                            repository.insertEpisode(episode)
+                            // エラー発生時も既存データを保持（本文なしでの上書き禁止）
                         }
 
                         val progress = (index + 1).toFloat() / episodesToDownload.size
@@ -734,8 +733,7 @@ class UpdateService : Service() {
                     )
                     repository.updateNovel(updatedNovel)
 
-                    // 既存エピソードを全削除（再取得なので最初からやり直す）
-                    repository.deleteEpisodesByNcode(ncode)
+                    // 既存エピソードは削除しない。insertEpisode が is_read/is_bookmark/reading_rate を保持してマージする。
                 }
 
                 if (!isRunning || session.isCancelled()) {
@@ -984,12 +982,12 @@ class UpdateService : Service() {
 
                                 if (episodeBody.isEmpty() || episodeBody.startsWith("★HTMLページ読み込みエラー")) {
                                     Log.e(TAG, "Failed to fetch episode body after ${maxRetries} retries: $episodeNoInt")
+                                } else {
+                                    // 正常取得できた場合のみ保存（エラー文字列で上書きしない）
+                                    val episodeWithBody = episodeInfo.copy(body = episodeBody)
+                                    repository.insertEpisode(episodeWithBody)
+                                    successCount++
                                 }
-
-                                // 本文を含めてエピソードを保存（1話ずつ）
-                                val episodeWithBody = episodeInfo.copy(body = episodeBody)
-                                repository.insertEpisode(episodeWithBody)
-                                successCount++
                             }
                         } catch (e: Exception) {
                             Log.e(TAG, "Failed to fetch episode $episodeNoInt: ${e.message}")

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
@@ -90,7 +90,7 @@ class AutoUpdateScheduler(private val context: Context) {
     }
 
     /**
-     * 手動で更新チェックを即座に実行
+     * 手動で更新チェックを即座に実行（二重起動を防ぐため enqueueUniqueWork を使用）
      */
     fun runManualUpdate() {
         val constraints = Constraints.Builder()
@@ -102,7 +102,11 @@ class AutoUpdateScheduler(private val context: Context) {
             .addTag("manual_update")
             .build()
 
-        workManager.enqueue(workRequest)
+        workManager.enqueueUniqueWork(
+            "manual_update_work",
+            ExistingWorkPolicy.KEEP,
+            workRequest
+        )
         Log.d(TAG, "手動更新を実行")
     }
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateScheduler.kt
@@ -28,6 +28,14 @@ class AutoUpdateScheduler(private val context: Context) {
      * @param timeString 時刻文字列 (例: "03:00")
      */
     fun scheduleAutoUpdate(enabled: Boolean, timeString: String) {
+        scheduleAutoUpdateInternal(enabled, timeString, ExistingPeriodicWorkPolicy.KEEP)
+    }
+
+    private fun scheduleAutoUpdateInternal(
+        enabled: Boolean,
+        timeString: String,
+        existingWorkPolicy: ExistingPeriodicWorkPolicy
+    ) {
         if (!enabled) {
             cancelAutoUpdate()
             return
@@ -36,8 +44,8 @@ class AutoUpdateScheduler(private val context: Context) {
         try {
             val (hour, minute) = parseTimeString(timeString)
             val delay = calculateInitialDelay(hour, minute)
-            
-            Log.d(TAG, "自動更新スケジュール設定: ${timeString} (${delay}分後に開始)")
+
+            Log.d(TAG, "自動更新スケジュール設定: ${timeString} (${delay}分後に開始, policy=$existingWorkPolicy)")
 
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
@@ -52,7 +60,7 @@ class AutoUpdateScheduler(private val context: Context) {
 
             workManager.enqueueUniquePeriodicWork(
                 WORK_NAME,
-                ExistingPeriodicWorkPolicy.REPLACE,
+                existingWorkPolicy,
                 workRequest
             )
 
@@ -129,11 +137,8 @@ class AutoUpdateScheduler(private val context: Context) {
      * @param timeString 時刻文字列 (例: "03:00")
      */
     fun resetSchedule(enabled: Boolean, timeString: String) {
-        // 既存のワークをキャンセル
-        cancelAutoUpdate()
-
-        // 再スケジュール
-        scheduleAutoUpdate(enabled, timeString)
+        // 設定変更時は REPLACE で強制的に再スケジュール（起動時の KEEP とは区別）
+        scheduleAutoUpdateInternal(enabled, timeString, ExistingPeriodicWorkPolicy.REPLACE)
 
         Log.d(TAG, "スケジュールをリセットしました")
     }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -35,6 +35,7 @@ import com.shunlight_library.novel_reader.api.NovelApiUtils
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapterFactory
 import com.shunlight_library.novel_reader.data.adapter.NovelSiteAdapter
 import com.shunlight_library.novel_reader.data.adapter.KakuyomuAdapter
+import com.shunlight_library.novel_reader.data.entity.EpisodeMappingEntity
 import com.shunlight_library.novel_reader.utils.AppLogger
 import com.shunlight_library.novel_reader.utils.PseudoNcodeGenerator
 import com.shunlight_library.novel_reader.utils.NovelUpdateCoordinator
@@ -498,6 +499,23 @@ class AutoUpdateWorker(
         val mappings = kakuyomuAdapter.getCachedMappings()
         val episodeTitles = episodeListFromWeb.associate {
             it.episode_no.toIntOrNull() to (it.e_title ?: "第${it.episode_no}話")
+        }
+
+        // episode_mapping テーブルに最新マッピングを保存（CLAUDE.md ルール14）
+        if (mappings.isNotEmpty()) {
+            try {
+                val mappingEntities = mappings.map { (episodeNo, kakuyomuId) ->
+                    EpisodeMappingEntity(
+                        ncode = novel.ncode,
+                        episode_no = episodeNo,
+                        kakuyomu_episode_id = kakuyomuId
+                    )
+                }
+                repository.insertEpisodeMappings(mappingEntities)
+                Log.d(TAG, "episode_mapping 保存完了: ${novel.ncode}, ${mappingEntities.size}件")
+            } catch (e: Exception) {
+                Log.w(TAG, "episode_mapping 保存失敗: ${novel.ncode}", e)
+            }
         }
 
         episodeNos.forEach { episodeNo ->

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -304,10 +304,6 @@ class AutoUpdateWorker(
                                 totalSuccessEpisodes += downloadInfo.successEpisodes.size
                                 totalFailedEpisodes += downloadInfo.failedEpisodes.size
 
-                                // 小説のtotal_ep値を更新
-                                val updatedNovel = novel.copy(total_ep = queueItem.general_all_no)
-                                repository.updateNovel(updatedNovel)
-
                                 // ダウンロードしたエピソードをエラーログに保存（失敗のみ）
                                 downloadInfo.failedEpisodes.forEach { failedEpisode ->
                                     errorLogStore.addErrorLog(
@@ -325,8 +321,23 @@ class AutoUpdateWorker(
                                     )
                                 }
 
-                                // 全エピソードダウンロード完了時は更新キューから削除
-                                repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                                if (downloadInfo.failedEpisodes.isEmpty()) {
+                                    // 全話成功時のみ total_ep を確定し更新キューから削除
+                                    val updatedNovel = novel.copy(total_ep = queueItem.general_all_no)
+                                    repository.updateNovel(updatedNovel)
+                                    repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                                } else {
+                                    // 一部失敗: 実際に保存された最大話数を total_ep に反映し、
+                                    // キューを残して次回の更新確認でリトライ可能にする
+                                    val maxSavedEp = repository.getEpisodesByNcode(novel.ncode).first()
+                                        .mapNotNull { it.episode_no.toIntOrNull() }.maxOrNull() ?: novel.total_ep
+                                    repository.updateNovel(novel.copy(total_ep = maxSavedEp))
+                                    if (maxSavedEp >= queueItem.general_all_no) {
+                                        // 末尾まで保存済み（途中の欠番はエラー修正で再取得可能）
+                                        repository.deleteUpdateQueueByNcode(queueItem.ncode)
+                                    }
+                                    Log.w(TAG, "自動DLで${downloadInfo.failedEpisodes.size}件失敗: ${queueItem.ncode} (保存済み最大話数: $maxSavedEp)")
+                                }
                             }
                         } finally {
                             NovelUpdateCoordinator.finishUpdate(session)

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -17,6 +17,7 @@ import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import kotlinx.coroutines.CancellationException
 import com.shunlight_library.novel_reader.MainActivity
 import com.shunlight_library.novel_reader.NovelReaderApplication
 import com.shunlight_library.novel_reader.R
@@ -108,6 +109,9 @@ class AutoUpdateWorker(
 
             Log.d(TAG, "自動更新処理完了")
             Result.success()
+        } catch (e: CancellationException) {
+            // WorkManager による正常キャンセル（REPLACE, 10分制限等）はエラー通知しない
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "自動更新処理中にエラーが発生", e)
             val errorMsg = e.message ?: "不明なエラー"
@@ -204,8 +208,8 @@ class AutoUpdateWorker(
                                         if (latestEpisodeCount > novel.total_ep) {
                                             updateQueueItem = UpdateQueueEntity(
                                                 ncode = novel.ncode,
-                                                total_ep = latestEpisodeCount,
-                                                general_all_no = novel.total_ep,
+                                                total_ep = novel.total_ep,
+                                                general_all_no = latestEpisodeCount,
                                                 update_time = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
                                             )
 
@@ -293,14 +297,14 @@ class AutoUpdateWorker(
                                 return@forEach
                             }
 
-                            val downloadInfo = downloadEpisodesForNovel(novel, queueItem.general_all_no, queueItem.total_ep)
+                            val downloadInfo = downloadEpisodesForNovel(novel, queueItem.total_ep, queueItem.general_all_no)
                             if (downloadInfo != null) {
                                 downloadDetails.add(downloadInfo)
                                 totalSuccessEpisodes += downloadInfo.successEpisodes.size
                                 totalFailedEpisodes += downloadInfo.failedEpisodes.size
 
                                 // 小説のtotal_ep値を更新
-                                val updatedNovel = novel.copy(total_ep = queueItem.total_ep)
+                                val updatedNovel = novel.copy(total_ep = queueItem.general_all_no)
                                 repository.updateNovel(updatedNovel)
 
                                 // ダウンロードしたエピソードをエラーログに保存（失敗のみ）

--- a/codebase_audit_2026-06-11.md
+++ b/codebase_audit_2026-06-11.md
@@ -1,0 +1,176 @@
+# コードベース全体監査レポート (2026-06-11)
+
+対象: Novel_reader_app (バージョン 2.0.6 / DB v16)
+監査範囲: ①ダウンロード・サイトアダプター層 ②データベース・マイグレーション・リポジトリ ③バックグラウンド処理・自動更新・通知 ④UI・パフォーマンス・多サイト対応
+
+---
+
+## 🔴 最優先（機能が壊れている / データ消失・クラッシュ）
+
+### 1. 手動更新が一切実行されない回帰
+- `service/UpdateService.kt:115-141`
+- 最初の `ACTION_START_UPDATE` でオペレーションを `operationQueue` に積まずに `processNextOperation()` を呼ぶため、キューが空 → 即「全ての更新処理が完了しました」通知 → 3秒後に stopSelf。手動の更新チェック/再DL/エラー修正/一括更新がすべて空振りする。コミット ae467cd のキュー化リファクタで混入。
+- 修正: 分岐内で `operationQueue.add(UpdateOperation(ncode, requestedUpdateType))` してから `processNextOperation()`。
+
+### 2. update_queue のフィールド逆転（3観点の監査すべてで検出）
+- `worker/AutoUpdateWorker.kt:205-209`
+- `total_ep=API最新値, general_all_no=ローカル値` で格納しており、エンティティ定義・`UpdateService.kt:511-516`・`UpdateInfoScreen.kt:586-591` の正準（total_ep=現状、general_all_no=最新）と真逆。自動DL無効時、未取得話数が0/負数になり一括DLが全件スキップ → **#1と組み合わさると自動DLオフ環境では更新が一切取り込めない**。
+- 修正: `total_ep=novel.total_ep, general_all_no=latestEpisodeCount` に統一。`AutoUpdateWorker.kt:296-303` の `downloadEpisodesForNovel` 引数も反転修正。
+
+### 3. カクヨム登録キューの ncode 不整合 — 新規登録が本体DBに統合されない
+- `manager/RegistrationQueueManager.kt:100, 275-287, 322-383, 157`
+- `addToQueue` は生の workId 数字列を `queue.ncode` に保存するが、temp_episodes・novels_descs・episode_mapping は疑似Ncode（"K"+Base62）で保存される。完了時の `mergeTempEpisodesToMain(queue.ncode)` が0件ヒット → **エピソードが episodes テーブルへ統合されず temp行が孤児として永久残留**。タイムアウトレジューム・重複登録チェック・キャンセル時のtemp掃除もすべて機能しない。
+- 修正: `addToQueue` でカクヨムは `PseudoNcodeGenerator.generateKakuyomuNcode(novelId)` に変換してから格納（1箇所の修正で merge/resume/dup/cleanup すべて復旧）。
+
+### 4. 通知の「すべてダウンロード」がカクヨム新着で系統的に失敗
+- `service/UpdateService.kt:1241-1261`（performBulkUpdate）
+- サイト分岐なしで `NovelApiUtils.fetchEpisodeWithRetry` を使用。カクヨム新着話は episode_mapping 未登録のため連番をカクヨムIDとして URL 生成 → 404 → 全話失敗。マッピング更新処理もない（CLAUDE.md ルール14違反）。
+- 修正: カクヨム分岐を追加し `fetchNovelMetadataWithEpisodeList` で mapping 更新後に本文取得。
+
+### 5. KakuyomuAdapter の cachedMappings 共有可変状態 — 別作品の本文混入リスク
+- `data/adapter/KakuyomuAdapter.kt:65,79,816-831` + `NovelSiteAdapterFactory.kt:22-25`
+- シングルトン共有インスタンスの `cachedMappings` を AutoUpdateWorker と UpdateService/UI 操作の双方が「fetch→getCachedMappings」の2段階で利用。ncode単位ロックは別小説間の共有状態を守らないため、並行処理時に**別作品のエピソードIDで本文を取得・保存**し得る。
+- 修正: fetch系メソッドがマッピングを戻り値で返す設計にして可変共有状態を排除。
+
+### 6. DB同期の互換性チェックがテーブル名不一致で破綻
+- `data/sync/ImprovedDatabaseSyncManager.kt:144` vs `:567,580`
+- チェックは `rast_read_novel` を必須とするが読取は `last_read_novel` を照会。本アプリ自身のエクスポートが生成するDBは `last_read_novel` のみ → **自分のバックアップのインポートが常に拒否される**。レガシーDBなら逆に途中で SQLiteException。
+- 修正: `isTableExists` で動的判定し、存在する方を要求・照会。
+
+### 7. DB同期で is_favorite / site_type / sub_site / end_flag が消失
+- `data/sync/DatabaseSyncManager.kt:220-236` / `ImprovedDatabaseSyncManager.kt:337-356`
+- 外部DBからこれらを読まずデフォルト値（site_type=1, is_favorite=0）で REPLACE 上書き。**同期でお気に入り全消失、カクヨム作品がなろう扱いに化けてアダプター誤選択**。
+- 修正: 外部DBに列があれば読み、無ければ内部DBの既存値とマージ。
+
+### 8. 同期バッチで既読・しおり・読書率がリセット
+- `data/sync/DatabaseSyncManager.kt:310-336` + `NovelRepository.kt:168`
+- 20件バッチが複数ncodeをまたぐと `insertEpisodes(preserveExisting=true)` が先頭ncodeの既存分しか参照せず、他ncodeの既読情報が REPLACE で0に。
+- 修正: 保存前に `groupBy { it.ncode }` してncode単位で呼ぶ。
+
+### 9. v6以前からのアップグレードで Room スキーマ検証クラッシュ
+- `NovelDatabase.kt:110-112` + `ImageCacheEntity.kt:11`
+- MIGRATION_6_7 が `idx_image_cache_hash` を作成するがエンティティは indices 未宣言。Room 2.7.0 は余分なインデックスも不一致扱い → "Migration didn't properly handle: image_cache" でクラッシュ。
+- 修正: エンティティに `Index(value=["hash"], name="idx_image_cache_hash")` を追加。
+
+### 10. Android 13+ で通知が全て無音破棄（POST_NOTIFICATIONS 未要求）
+- `MainActivity.kt` 全体 / `AndroidManifest.xml:7`
+- マニフェスト宣言のみでランタイム要求がない（targetSdk=34）。自動更新結果・エラー・FGS通知が表示されない。
+- 修正: 起動時に `ActivityResultContracts.RequestPermission` で要求。
+
+### 11. アプリ起動毎の REPLACE 再スケジュールが実行中の自動更新を殺す
+- `NovelReaderApplication.kt:62-68` + `worker/AutoUpdateScheduler.kt:53-57`
+- Worker実行のためのプロセス起動時にも `ExistingPeriodicWorkPolicy.REPLACE` で再enqueueされ、実行中ワークがキャンセルされ得る。さらに `AutoUpdateWorker.kt:111-136` の `catch (e: Exception)` が CancellationException を握り潰し「自動更新エラー」通知に化ける。
+- 修正: 起動時復元は UPDATE/KEEP に、REPLACE は設定変更時のみ。catch 先頭で `if (e is CancellationException) throw e`。
+
+### 12. 縦書きモードの読書進捗が保存されない
+- `ui/components/VjapVerticalTextView.kt:61-73` + `EpisodeViewScreen.kt:89,190-195`
+- `onReadingRateChanged` が「復元直後」と「最終ページ」でしか発火せず、途中のページ送りが追跡されない。保存されるのは開いた時点のレートか1.0のみ（横書きはJS監視で逐次保存＝パリティ欠陥）。
+- 修正: ページ変更コールバックを追加し毎ページ通知。
+
+### 13. カクヨムHTMLフォールバック経路で NumberFormatException クラッシュ / 全話スキップ
+- `data/adapter/KakuyomuAdapter.kt:869-944`
+- 方法3（sidebar/目次とも失敗時）で `episode_no` に19桁のカクヨムIDを格納。`fetchNovelWithEpisodesIncludingMappings:194` の `toInt()` で即クラッシュ、`RegistrationQueueManager.kt:458` では全話を黙ってスキップ。cachedMappings 未更新で別作品のマッピング残留（クロス汚染）も。
+- 修正: 方法3でも連番 episode_no＋マッピング構築。fetch系メソッド冒頭で `cachedMappings` リセット。
+
+### 14. TopAppBar の戻るボタンでバックスタックが増殖
+- `MainActivity.kt:330, 341-343`
+- 戻るが `navigateBack()` ではなく `navigateTo(Screen.Main)` 等（navigateTo は現画面を push）。戻るたびにスタックが増え、システムバックで過去画面が延々再表示。EpisodeList の `source` も無視される。
+- 修正: onBack は `navigateBack()`（EpisodeList は `navigateBackTo(source)`）へ統一。
+
+---
+
+## 🟠 中（パフォーマンス劣化・ルール違反・条件付き不具合）
+
+### ダウンロード・アダプター層
+- **D1** `UpdateInfoScreen.kt:291` — 欠落修正スキャンが `fetchNovelWithEpisodes` で**全話本文をDL**して話数カウントのみに使用（1000話作品で約10分＋数十MB浪費）。→ `fetchUpdateSummary()` に置換。
+- **D2** `EpisodeListScreen.kt:654-667` — カクヨム再取得が repository 引数なしの旧方式で全話メモリ蓄積（逐次保存ルール違反、OOMリスク）。→ `repository` を渡すストリーミング方式に。
+- **D3** `api/NovelApiUtils.kt:530-540` — カクヨム分岐がタイトル取得のため同一ページを `Jsoup.connect` で**レート制限なしに二重取得**。タイトル優先順位から `p.widget-episodeTitle` も欠落。→ `fetchEpisodeDetails()` に差し替え。
+- **D4** `worker/AutoUpdateWorker.kt:445-559` — カクヨムDLで episode_mapping を保存しない（ルール14違反）。新着話の閲覧URL生成・エラー修正が失敗する。→ `getCachedMappings()` を `insertEpisodeMappings()` で保存。
+- **D5** `KakuyomuAdapter.kt:424-430` / `NovelApiUtils.kt:57-63` — レート制限の `lastAccessTime` が非volatile・無同期。30並列バッチで0.5秒間隔が実質無効化。→ Mutex で保護。
+- **D6** `api/NovelApiUtils.kt:967-988` — 改稿チェックが `<span title="...改稿">` の title 属性を読まず初出掲載日を参照、**改稿が検出されない**。→ `span[title]` から改稿日時をパース。
+- **D7** `UpdateService.kt:1305-1312` / `AutoUpdateWorker.kt:296-325` / `UpdateInfoScreen.kt:1057-1062` — DL失敗話があっても total_ep を最新値に更新しキューを削除 → **欠番が恒久化**（エラー修正以外で復旧不能）。→ 失敗がある場合は実保存数で更新しキュー保持。
+- **D8** `RegistrationQueueManager.kt:498-510` — なろう登録で total_ep をDL前に確定。途中失敗しても不足分が更新チェックで検出されない。→ 完了時に実保存数で上書き。
+- **D9** `UpdateService.kt:619` — 再取得（UPDATE_TYPE_DOWNLOAD）が全削除→再挿入のため**既読・しおり・読書率・マッピングが全消失**。途中キャンセルで中途半端な状態が残る。→ 削除せず上書きマージに。
+- **D10** `RegistrationQueueManager.kt:574-579` — 進捗更新のたびに `updateNovelInfo(id, "", total)` でキューの **title を空文字上書き**（DL状況画面が空欄に）。→ total のみ更新する専用クエリに分離。
+- **D11** `EpisodeListScreen.kt:995-1007` — エラー修正（カクヨム）が「★HTMLページ読み込みエラー」文をそのまま本文として保存し成功扱い。→ UpdateService 同等の判定＋再試行を追加。
+- **D12** `DatabaseSyncManager.kt:242-244` — `&json` 付き api_url を生成・保存（CLAUDE.md の YAML ルール違反）。→ `getOrCreateURL` と同一形式に統一。
+
+### バックグラウンド・サービス
+- **B1** `UpdateService.kt:306-338` — 403時の再開が `PendingIntent.getService`＋exact alarm。API26+のBG起動制限で機能せず、API31-32では `canScheduleExactAlarms()` 未チェックで SecurityException の恐れ。→ WorkManager フォールバック。
+- **B2** `AndroidManifest.xml:16-17` — `USE_EXACT_ALARM` 宣言は Play 審査リジェクトリスク。→ 削除して `SCHEDULE_EXACT_ALARM`＋権限チェックに一本化。
+- **B3** `receiver/DownloadAllReceiver.kt:36` — 通知アクションから `startService()`（API26+で IllegalStateException）。`ACTION_DOWNLOAD_ALL` の送信側も未実装、`DownloadActionReceiver` はマニフェスト未登録のデッドコード。
+- **B4** `worker/AutoUpdateScheduler.kt:87-99` — 手動更新が非uniqueの enqueue で多重並走可能（`clearAllUpdateQueue` が互いのキューを消し合う）。→ `enqueueUniqueWork(KEEP)`。
+- **B5** `worker/AutoUpdateWorker.kt:86-90` — setForeground 失敗時にBG継続 → 非FGS Workerの約10分制限で大量DLが途中キャンセル。
+- **B6** `UpdateService.kt:63,91` — operationQueue / updateListeners / isRunning をメインと IO から無同期アクセス。
+
+### データベース・同期
+- **DB1** `NovelRepository.kt:379-393, 249-303, 1126-1147` — `deleteNovelWithRelations`（5テーブル削除）等の複合書込にトランザクションなし（プロジェクト全体で withTransaction 使用ゼロ）。→ `database.withTransaction {}` で包む。
+- **DB2** `RegistrationQueueManager.kt:66-79` — プロセス強制終了後の STATUS_PROCESSING 残骸を復旧せず、2件溜まると **MAX_CONCURRENT=2 に達してキューが永久停止**。→ 起動時に PROCESSING → PENDING リセット。
+- **DB3** `RegistrationQueueManager.kt:152-167` — cancelQueue が temp削除→job cancel の順で temp_episodes が孤児化するレース。→ `cancelAndJoin()` 後に削除。
+- **DB4** `DatabaseSyncManager.kt:381` / `ImprovedDatabaseSyncManager.kt:604` — インポート時に読書履歴の日時を現在時刻で上書き（「最近読んだ」順序が全件潰れる）。
+- **DB5** `NovelDatabase.kt:305` — exportSchema=false かつ room.schemaLocation 未設定で **MigrationTest が実行不能**。テストも v11 まででv12-16未カバー。
+- **DB6** `DatabaseSchemaAnalyzer.kt:84-85` — DBクローズ・一時ファイル削除が finally 外（ハンドルリーク）。
+
+### UI・パフォーマンス
+- **U1** `EpisodeListScreen.kt:149-157` — 目次表示が `SELECT *`（本文込み）の全話を Compose state に保持。長編で数十MB消費＋emit毎の全件ソート。→ body 除外のプロジェクションDTOクエリに。
+- **U2** `UpdateInfoScreen.kt:875,912` — 一括DLループが1話ごとに全話（本文込み）を `.first()` で再ロード（N×M）。→ `getEpisode(ncode, no)` 単発取得に。
+- **U3** `EpisodeViewScreen.kt:1004-1011` — AndroidView update で毎リコンポジション `loadDataWithBaseURL` 実行 → しおりトグル等でページ再読込・スクロール巻き戻り。
+- **U4** `EpisodeViewScreen.kt:768-793` vs `utils/VjapTextConverter.kt` — ルビ処理のパリティ欠如: 壊れタグ修復＋autoRubyEnabled は横書きWebViewのみで、**縦書きでは設定が完全に無視される**。→ 縦書き変換前に fixRubyTags 相当を適用。
+- **U5** `EpisodeViewScreen.kt:976-1001` — JS有効＋JSブリッジ＋allowFileAccess=true でスクレイピング由来の未サニタイズHTMLをロード（XSS→ブリッジ呼出し・file://参照が可能）。→ script除去 or allowFileAccess無効化＋WebViewAssetLoader。
+- **U6** `WebViewScreen.kt:452-458` — update ブロックが状態変化のたび `loadUrl` 再実行（入力・スクロール喪失）。
+- **U7** WebView 未破棄（両画面、`onCreateWindow` の tempWebView も）→ ネイティブリソースリーク。→ `AndroidView(onRelease = { it.destroy() })`。
+- **U8** `NovelListScreen.kt:209-347` — 全小説をメモリ保持し検索1文字ごとにUIスレッドで filter＋sort（DBインデックスが活きない）。→ SQL側絞り込み or Dispatchers.Default。
+- **U9** `EpisodeListScreen.kt:1601-1615` — 作者ページURLが site_type 分岐なしで syosetu mypage 固定（アダプター外ハードコード、カクヨムで壊れる）。
+- **U10** `RecentlyReadNovelsScreen.kt:51` — フィルター設定の永続化なし（CLAUDE.md ルール違反）。
+- **U11** `NovelDescDao.kt:49` — `getNovelsByNcodes` の IN句未チャンクで999件超に SQLite 変数上限例外リスク。
+
+---
+
+## 🟡 低（品質・保守性）
+
+- LazyColumn の key 未指定: EpisodeListScreen:1880 / RecentlyRead:199 / RecentlyUpdated:81 / UpdateInfo:1237
+- `EpisodeViewScreen.kt` — saveReadingRate が onDispose/ON_PAUSE で呼ばれない（ホーム遷移で進捗喪失）。fontSize 初期値18 vs デフォルト16のドリフト
+- `fixRubyTags` が半角括弧のみ対象（仕様の全角「漢字（よみがな）」が変換されない）＋漢字限定でないため英文 `word(note)` を誤ルビ化
+- end_flag=0（不明）が完結/未完結フィルターのどちらでも除外され不可視に
+- `NovelDatabase.kt:280-281` — v16 の sub_site 初期化が R18 を一律ノクターン(2)扱い（ムーンライト/ミッドナイト誤分類）
+- `ImprovedDatabaseSyncManager.kt:262` — エルビス演算子の優先順位バグで進捗スロットリングが無効
+- 通知ID衝突（FCM 1000+ と AutoUpdateWorker 1001/1002）、1話毎 notify のレート制限超過
+- `AutoUpdateWorker.kt:136` — 常に failure で retry 不使用（一時障害でその日の自動更新消失）。PeriodicWork のドリフトで指定時刻からズレ続ける
+- `PER_EPISODE_TIMEOUT_MS` 未使用（1話ハングは全体10分まで待つ）、進捗更新の fire-and-forget で逆行
+- `NovelRepository.kt:600-864` の `addNovelByUrl`/`addNovelByNcode` はデッドコード（かつバグ含み）→ 削除推奨
+- `android.util.Log` 直接使用が多数（AppLogger ルール違反、リリースでもログ出力）: NovelApiUtils / UpdateService / AutoUpdateWorker / EpisodeListScreen / KakuyomuAdapter
+- アダプターパターン違反: `NovelApiUtils.kt:507-558` のカクヨム分岐＋直接 new、`EpisodeListScreen.kt:650,966` のファクトリ不使用
+- 完結判定が `doc.text()` 全体への「完結済」包含チェック（あらすじ等で誤検知）
+- `shouldOverrideUrlLoading` が非httpスキーム（intent:// 等）を loadUrl（WebViewScreen.kt:222）
+- MainActivity のデッド state（showSettings 等）と重複初期化
+- CLAUDE.md のドキュメント乖離: 本文に「7 Entities / 7 DAOs / v11 / 2.0.4」が残存（正: 9/9/v16/2.0.6）。episodes のカラム名（e_no/e_body→実際は episode_no/body）、テーブル名 `last_read_novels`→実際は `last_read_novel`、疑似Ncode「KK-」→実装は「K」プレフィックス、KakuyomuAdapter コメントの「0.1秒間隔」→実装500ms
+
+---
+
+## ✅ 正しく実装されていると確認した主要項目
+
+- **マイグレーションチェーン v1→v16**: 15本すべて定義・登録済み、destructive migration なし。v12/v16 のインデックスはエンティティ・マイグレーション両方に存在し名前一致
+- **エンティティ9 / DAO9 / DB v16**: CLAUDE.md Quick Reference と実コード一致
+- **Repositoryパターン / Flow・suspend 規約**: DAO直アクセスはDI組み立てのみ。メインスレッドDBアクセスなし
+- **Syosetu YAML/gzip**: gzip二重判定・fixYamlFoldedScalarIndentation・レスポンス[1]参照すべて規定通り
+- **R18判定**: 全ライブフローで rating==1 → novel18 系を一貫使用
+- **短編タイトルフォールバック**: `--rensai` → 汎用セレクタの順で実装済み
+- **KakuyomuAdapter 規定実装**: 本文/タイトル/章セレクタ優先順位、dots-indicator チェック、3回再試行＋指数バックオフ、cleanup 系、アダプター内全リクエストへの applyRateLimit 適用
+- **逐次保存**: 主要DL経路（RegistrationQueueManager temp経由 / UpdateService / AutoUpdateWorker / UpdateInfoScreen）は1話ずつ保存（例外は上記 D2）
+- **既読保持マージ**: insertEpisode 系は本文空なら旧本文保持＋既読/しおり/読書率保持
+- **自動更新フロー**: 開始時 clearAllUpdateQueue、全小説対象、chunked(30)+async、カクヨムはメタデータのみ — 仕様準拠
+- **マニフェスト**: receiver/service すべて exported=false、FGS dataSync 型宣言済み（Android 14対応）
+- **バックハンドラー**: OnBackPressedCallback＋navigateBack（deprecated onBackPressed 不使用）
+- **NovelListScreen**: フィルター永続化・enum安全復元・スクロール位置保存・LazyColumn key すべて実装済み
+- **N+1対策**: UpdateInfoScreen / RecentlyRead の getNovelsByNcodes 一括取得は実装済み
+
+---
+
+## 推奨対応順序
+
+1. **#1 + #2**（手動更新の回帰＋キュー逆転）— 組み合わせで「更新が取り込めない」状態。即修正
+2. **#3**（カクヨム登録の ncode 不整合）— 新規登録の根幹が壊れている。1行修正で広範囲復旧
+3. **#6 + #7 + #8**（DB同期系）— バックアップ/復元がデータ破壊装置になっている
+4. **#9 + #10**（アップグレードクラッシュ・通知権限）— ユーザー影響大、修正容易
+5. **#4 + #5 + #13**（カクヨム mapping 系）— データ汚染リスク
+6. **#11 + #12 + #14**、その後 中項目（パフォーマンス系は U1/U2/D1 から）


### PR DESCRIPTION
## Summary

This PR addresses 14 critical bugs identified in the comprehensive codebase audit (2026-06-11), focusing on update queue handling, Kakuyomu registration, database synchronization, and UI consistency. These fixes restore core functionality that was broken or degraded in recent refactors.

## Key Changes

### Update Queue & Service (Critical)
- **Fix manual update regression**: `UpdateService.kt` now properly enqueues operations before processing, preventing immediate completion with empty queue
- **Fix update_queue field inversion**: Corrected `total_ep` and `general_all_no` field mapping in `AutoUpdateWorker.kt` to match entity definition and prevent skipped downloads
- **Preserve reading progress on re-download**: Changed `UPDATE_TYPE_DOWNLOAD` to merge episodes instead of deleting, preserving `is_read`, `is_bookmark`, and `reading_rate`
- **Prevent error string as episode body**: Only save fetched content if valid; skip saving on fetch failure to preserve existing data

### Kakuyomu Registration & Mapping (Critical)
- **Fix ncode mismatch in registration queue**: `RegistrationQueueManager.kt` now converts workId to pseudo-ncode (K+Base62) when adding to queue, ensuring `mergeTempEpisodesToMain` finds matching records
- **Fix bulk update for Kakuyomu**: `UpdateService.kt:performBulkUpdate` now handles Kakuyomu separately, fetching metadata with episode mappings before downloading content
- **Fix cachedMappings cross-contamination**: `KakuyomuAdapter.kt` resets `cachedMappings` at start of `parseEpisodeList` to prevent stale data from previous novels
- **Fix HTML fallback episode numbering**: Method 3 (HTML fallback) now uses sequential episode numbers and constructs mappings, preventing NumberFormatException and skipped episodes

### Database Synchronization (Critical)
- **Fix table name mismatch**: `ImprovedDatabaseSyncManager.kt` now dynamically checks for both `last_read_novel` and `rast_read_novel` table names, allowing self-backup imports
- **Preserve metadata on sync**: Import now reads `is_favorite`, `site_type`, `sub_site`, `end_flag` from external DB if present, falling back to internal values if absent
- **Fix batch sync data loss**: `NovelRepository.kt:insertEpisodes` now groups episodes by ncode before merging, preventing cross-ncode data loss in multi-ncode batches
- **Fix Room schema validation**: `ImageCacheEntity.kt` now declares `idx_image_cache_hash` index to match migration, preventing v6→v7 upgrade crash

### Background Work & Scheduling
- **Fix CancellationException handling**: `AutoUpdateWorker.kt` now re-throws `CancellationException` instead of treating it as error, preventing false error notifications on normal cancellation
- **Fix manual update double-execution**: `AutoUpdateScheduler.kt` now uses `enqueueUniqueWork(KEEP)` for manual updates to prevent concurrent execution
- **Fix startup re-scheduling**: `AutoUpdateScheduler.kt` uses `UPDATE`/`KEEP` policy on startup, only `REPLACE` on settings change, preventing in-flight worker cancellation
- **Reset stuck processing queues**: `RegistrationQueueManager.kt` resets `STATUS_PROCESSING` remnants on startup to prevent queue deadlock

### UI & Reading Experience
- **Fix vertical text reading progress**: `EpisodeViewScreen.kt` now applies ruby fixes to vertical text and passes `autoRubyEnabled` setting to `VjapVerticalTextView`
- **Add auto-ruby toggle**: `SettingsStore.kt` and `SettingsScreen.kt` now support persistent `autoRubyEnabled` setting (default: true)
- **Fix revision detection**: `NovelApiUtils.kt` now reads revision date from `<span title>` attribute instead of relying on text content, correctly detecting revised episodes

### Notifications & Permissions
- **Request POST_NOTIFICATIONS permission**: `MainActivity.kt` now requests notification permission at runtime for Android 13+ using `ActivityResultContracts.Request

https://claude.ai/code/session_01JVPoNUpqDS9b9yWtx9PZyF