### PR TITLE
修正バッチ9: 縦書きブラッシュアップ・作者ページ遷移・エラー本文防止 (v2.0.15)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## 📖 Quick Reference
 
 ### Current State (2026-06-12)
-- **Version**: 2.0.14 (versionCode: 214)
+- **Version**: 2.0.15 (versionCode: 215)
 - **Database**: Version 16 with 9 tables + performance indices
 - **Supported Sites**: Syosetu (なろう小説) + Kakuyomu (カクヨム)
 - **Architecture**: Clean + MVVM + Repository + Adapter Pattern
@@ -131,7 +131,7 @@ All Gradle commands should be run from the `Novel_reader/` directory.
 Novel_reader_app/
 ├── Novel_reader/                    # Main Android project
 │   ├── app/
-│   │   ├── build.gradle.kts        # App build config (version: 2.0.4, code: 204)
+│   │   ├── build.gradle.kts        # App build config (version: 2.0.15, code: 215)
 │   │   └── src/
 │   │       ├── main/java/com/shunlight_library/novel_reader/
 │   │       │   ├── *.kt            # Top-level screens and application
@@ -360,6 +360,13 @@ Use `SettingsStore` for persistent configuration with DataStore.
 - Schema export: exportSchema=true + room.schemaLocation 設定（v16以降のマイグレーションテスト基盤）
 - Cancel race fix: RegistrationQueueManager.cancelQueue でジョブを cancelAndJoin してから一時データ削除（孤児 temp_episodes 防止）
 - Episode list lightweight loading: EpisodeMeta DTO（本文なし射影 + body_empty フラグ）と getEpisodeMetasByNcode により、EpisodeListScreen が全話の本文をメモリにロードせず一覧表示（1000話超でも軽量）
+- Author page navigation (v2.0.15): 作者ボタンをサイト対応化。なろう一般=mypage.syosetu.com/{userid}/、R18=xmypage.syosetu.com/{xid}/（novel18apiはuseridを返さず数値IDでは404のため、作品ページからxidをスクレイプしuseridにキャッシュ。NovelApiUtils.fetchR18AuthorId）、カクヨム=kakuyomu.jp/users/{スクリーンネーム}（Apollo stateのUserAccount.nameから取得。KakuyomuAdapter.fetchAuthorUserName、parseNovelInfoでもuserid保存）。解決したIDはrepository.updateNovelで永続化し次回以降ネットワーク不要
+- Vertical mode page progress (v2.0.15): VTextLayoutにOnPageChangedListener追加。縦書きでページをめくるたびに進捗率（page/totalPage）を保存できるようになった（従来は開いた時点と読了時のみ）
+- Vertical mode position preservation (v2.0.15): VjapVerticalTextViewのupdateで設定の差分適用（無条件setFontSize/setColorによる再レイアウト・ページ喪失を防止）。フォントサイズ変更時はrestoreRateで直前の読書位置を復元
+- Vertical kinsoku (v2.0.15): VTextViewの行頭禁則文字を拡充（小書き仮名・ー〜…‥！？：；等、ぶら下げ処理）、開き括弧の行末禁則を追加（行の最終マスなら先に改行）、余白を密度スケール化（18dp）
+- Episode navigation fix (v2.0.15): 前後話ナビでLaunchedEffect先頭にepisode=nullリセットを追加（旧話の本文が表示され続けるバグ修正）。EnhancedHtmlRubyWebViewをkey(ncode, episodeNo)で再生成（JSブリッジが古いepisodeNoで別話の進捗を上書きするバグ修正）。WebViewのHTML再ロードはタグ比較で変更時のみ
+- Error-body prevention (adapter paths, v2.0.15): KakuyomuAdapter内部の保存経路（一括DL・ストリーミング・旧方式）でnormalizeEpisodeBodyによりエラー文字列を空文字に正規化。EpisodeListScreenのエラー修正（カクヨム）、RegistrationQueueManager（初回登録ストリーミング）、NovelApiUtils（カクヨム単話取得）にもガード追加（全fetchEpisodeContent保存経路でエラー文字列の本文化を防止）
+- WebViewScreen fixes (v2.0.15): AndroidView updateでの再ロードを廃止（再コンポーズのたびにページがリロードされるバグ修正）。mailto:等の非http(s)スキームは外部アプリへ委譲。xmypage.syosetu.comにもover18 Cookieを事前設定
 
 ### Performance Optimizations
 
@@ -487,7 +494,7 @@ val episodes = adapter.fetchEpisodeList(novel.ncode)
 4. **Navigation**: Use NavigationManager for navigation to maintain proper back stack
 5. **R18 Content**: Handle R18 content appropriately with dialog-based site selection
 6. **Reading Progress**: Maintain reading progress, bookmark functionality, and reading rate in EpisodeViewScreen
-7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 2.0.0 → 2.0.1) when making any code changes in `Novel_reader/app/build.gradle.kts`. Current version: 2.0.4 (versionCode 204).
+7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 2.0.0 → 2.0.1) when making any code changes in `Novel_reader/app/build.gradle.kts`. Current version: 2.0.15 (versionCode 215).
 8. **Commit Messages**: Always write commit messages in Japanese
 9. **Incremental Episode Saving**: When fetching episodes (both Kakuyomu and Syosetu), always fetch and save one episode at a time. Never fetch all episodes into memory first - instead use: fetch episode 1 → save to DB → fetch episode 2 → save to DB, etc. This applies to all re-download, update, and error-fix operations.
 10. **Multi-Site Support**: Use the Adapter pattern for site-specific logic. Never hardcode site-specific behavior outside of adapter implementations.

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 214
-        versionName = "2.0.14"
+        versionCode = 215
+        versionName = "2.0.15"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/schemas/com.shunlight_library.novel_reader.data.database.NovelDatabase/16.json
+++ b/Novel_reader/app/schemas/com.shunlight_library.novel_reader.data.database.NovelDatabase/16.json
@@ -1,0 +1,826 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 16,
+    "identityHash": "424294516e23467832eeffd6e28dfd64",
+    "entities": [
+      {
+        "tableName": "episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ncode` TEXT NOT NULL, `episode_no` TEXT NOT NULL, `body` TEXT NOT NULL, `e_title` TEXT NOT NULL, `update_time` TEXT NOT NULL, `is_read` INTEGER NOT NULL, `is_bookmark` INTEGER NOT NULL, `reading_rate` REAL NOT NULL, PRIMARY KEY(`ncode`, `episode_no`))",
+        "fields": [
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode_no",
+            "columnName": "episode_no",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "e_title",
+            "columnName": "e_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "update_time",
+            "columnName": "update_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_read",
+            "columnName": "is_read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_bookmark",
+            "columnName": "is_bookmark",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reading_rate",
+            "columnName": "reading_rate",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ncode",
+            "episode_no"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_episodes_ncode",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "episode_no"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_episodes_ncode` ON `${TABLE_NAME}` (`ncode`, `episode_no`)"
+          },
+          {
+            "name": "idx_episodes_is_read",
+            "unique": false,
+            "columnNames": [
+              "is_read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_episodes_is_read` ON `${TABLE_NAME}` (`is_read`)"
+          },
+          {
+            "name": "idx_episodes_is_bookmark",
+            "unique": false,
+            "columnNames": [
+              "is_bookmark"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_episodes_is_bookmark` ON `${TABLE_NAME}` (`is_bookmark`)"
+          },
+          {
+            "name": "idx_episodes_ncode_read",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "is_read"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_episodes_ncode_read` ON `${TABLE_NAME}` (`ncode`, `is_read`)"
+          },
+          {
+            "name": "idx_episodes_ncode_bookmark",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "is_bookmark"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_episodes_ncode_bookmark` ON `${TABLE_NAME}` (`ncode`, `is_bookmark`)"
+          }
+        ]
+      },
+      {
+        "tableName": "novels_descs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ncode` TEXT NOT NULL, `title` TEXT NOT NULL, `author` TEXT NOT NULL, `Synopsis` TEXT NOT NULL, `main_tag` TEXT NOT NULL, `sub_tag` TEXT NOT NULL, `rating` INTEGER NOT NULL, `last_update_date` TEXT NOT NULL, `total_ep` INTEGER NOT NULL, `general_all_no` INTEGER NOT NULL, `userid` TEXT, `noveltype` INTEGER, `length` INTEGER, `updated_at` TEXT NOT NULL, `is_favorite` INTEGER NOT NULL, `site_type` INTEGER NOT NULL, `registered_at` TEXT NOT NULL, `sub_site` INTEGER NOT NULL, `end_flag` INTEGER NOT NULL, `last_checked_at` TEXT NOT NULL, PRIMARY KEY(`ncode`))",
+        "fields": [
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "Synopsis",
+            "columnName": "Synopsis",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "main_tag",
+            "columnName": "main_tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sub_tag",
+            "columnName": "sub_tag",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rating",
+            "columnName": "rating",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "last_update_date",
+            "columnName": "last_update_date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total_ep",
+            "columnName": "total_ep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "general_all_no",
+            "columnName": "general_all_no",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userid",
+            "columnName": "userid",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "noveltype",
+            "columnName": "noveltype",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "length",
+            "columnName": "length",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "updated_at",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_favorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "site_type",
+            "columnName": "site_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "registered_at",
+            "columnName": "registered_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sub_site",
+            "columnName": "sub_site",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "end_flag",
+            "columnName": "end_flag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "last_checked_at",
+            "columnName": "last_checked_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ncode"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_novels_last_update",
+            "unique": false,
+            "columnNames": [
+              "last_update_date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_last_update` ON `${TABLE_NAME}` (`last_update_date`)"
+          },
+          {
+            "name": "idx_novels_update_check",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "rating",
+              "total_ep",
+              "general_all_no",
+              "updated_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_update_check` ON `${TABLE_NAME}` (`ncode`, `rating`, `total_ep`, `general_all_no`, `updated_at`)"
+          },
+          {
+            "name": "idx_novels_favorite",
+            "unique": false,
+            "columnNames": [
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_favorite` ON `${TABLE_NAME}` (`is_favorite`)"
+          },
+          {
+            "name": "idx_novels_length",
+            "unique": false,
+            "columnNames": [
+              "length"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_length` ON `${TABLE_NAME}` (`length`)"
+          },
+          {
+            "name": "idx_novels_type",
+            "unique": false,
+            "columnNames": [
+              "noveltype"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_type` ON `${TABLE_NAME}` (`noveltype`)"
+          },
+          {
+            "name": "idx_novels_site",
+            "unique": false,
+            "columnNames": [
+              "site_type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_site` ON `${TABLE_NAME}` (`site_type`)"
+          },
+          {
+            "name": "idx_novels_registered",
+            "unique": false,
+            "columnNames": [
+              "registered_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_registered` ON `${TABLE_NAME}` (`registered_at`)"
+          },
+          {
+            "name": "idx_novels_total_ep",
+            "unique": false,
+            "columnNames": [
+              "total_ep"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_total_ep` ON `${TABLE_NAME}` (`total_ep`)"
+          },
+          {
+            "name": "idx_novels_author",
+            "unique": false,
+            "columnNames": [
+              "author"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_author` ON `${TABLE_NAME}` (`author`)"
+          },
+          {
+            "name": "idx_novels_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "idx_novels_site_favorite",
+            "unique": false,
+            "columnNames": [
+              "site_type",
+              "is_favorite"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_site_favorite` ON `${TABLE_NAME}` (`site_type`, `is_favorite`)"
+          },
+          {
+            "name": "idx_novels_sub_site",
+            "unique": false,
+            "columnNames": [
+              "sub_site"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_sub_site` ON `${TABLE_NAME}` (`sub_site`)"
+          },
+          {
+            "name": "idx_novels_end_flag",
+            "unique": false,
+            "columnNames": [
+              "end_flag"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_end_flag` ON `${TABLE_NAME}` (`end_flag`)"
+          },
+          {
+            "name": "idx_novels_last_checked",
+            "unique": false,
+            "columnNames": [
+              "last_checked_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_novels_last_checked` ON `${TABLE_NAME}` (`last_checked_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "last_read_novel",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ncode` TEXT NOT NULL, `date` TEXT NOT NULL, `episode_no` INTEGER NOT NULL, PRIMARY KEY(`ncode`))",
+        "fields": [
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode_no",
+            "columnName": "episode_no",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ncode"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_last_read",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_last_read` ON `${TABLE_NAME}` (`ncode`, `date`)"
+          }
+        ]
+      },
+      {
+        "tableName": "update_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ncode` TEXT NOT NULL, `total_ep` INTEGER NOT NULL, `general_all_no` INTEGER NOT NULL, `update_time` TEXT NOT NULL, PRIMARY KEY(`ncode`))",
+        "fields": [
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total_ep",
+            "columnName": "total_ep",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "general_all_no",
+            "columnName": "general_all_no",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "update_time",
+            "columnName": "update_time",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ncode"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_update_queue_time",
+            "unique": false,
+            "columnNames": [
+              "update_time"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_update_queue_time` ON `${TABLE_NAME}` (`update_time`)"
+          }
+        ]
+      },
+      {
+        "tableName": "url_entity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ncode` TEXT NOT NULL, `api_url` TEXT NOT NULL, `url` TEXT NOT NULL, `is_r18` INTEGER NOT NULL, PRIMARY KEY(`ncode`))",
+        "fields": [
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "api_url",
+            "columnName": "api_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_r18",
+            "columnName": "is_r18",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ncode"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_url_entity_ncode",
+            "unique": false,
+            "columnNames": [
+              "ncode"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_url_entity_ncode` ON `${TABLE_NAME}` (`ncode`)"
+          }
+        ]
+      },
+      {
+        "tableName": "image_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`hash` TEXT NOT NULL, `original_url` TEXT NOT NULL, `local_path` TEXT NOT NULL, `mime_type` TEXT NOT NULL, PRIMARY KEY(`hash`))",
+        "fields": [
+          {
+            "fieldPath": "hash",
+            "columnName": "hash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "original_url",
+            "columnName": "original_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "local_path",
+            "columnName": "local_path",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mime_type",
+            "columnName": "mime_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "hash"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_image_cache_hash",
+            "unique": false,
+            "columnNames": [
+              "hash"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_image_cache_hash` ON `${TABLE_NAME}` (`hash`)"
+          }
+        ]
+      },
+      {
+        "tableName": "episode_mapping",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ncode` TEXT NOT NULL, `episode_no` INTEGER NOT NULL, `kakuyomu_episode_id` TEXT NOT NULL, PRIMARY KEY(`ncode`, `episode_no`))",
+        "fields": [
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode_no",
+            "columnName": "episode_no",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "kakuyomu_episode_id",
+            "columnName": "kakuyomu_episode_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ncode",
+            "episode_no"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_episode_mapping_ncode_no",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "episode_no"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_episode_mapping_ncode_no` ON `${TABLE_NAME}` (`ncode`, `episode_no`)"
+          },
+          {
+            "name": "idx_episode_mapping_ncode_id",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "kakuyomu_episode_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_episode_mapping_ncode_id` ON `${TABLE_NAME}` (`ncode`, `kakuyomu_episode_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "registration_queue",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ncode` TEXT NOT NULL, `site_type` INTEGER NOT NULL, `title` TEXT NOT NULL, `url` TEXT NOT NULL, `is_r18` INTEGER NOT NULL, `status` INTEGER NOT NULL, `current_episode` INTEGER NOT NULL, `total_episodes` INTEGER NOT NULL, `error_message` TEXT, `created_at` TEXT NOT NULL, `started_at` TEXT, `completed_at` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "site_type",
+            "columnName": "site_type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_r18",
+            "columnName": "is_r18",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "current_episode",
+            "columnName": "current_episode",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "total_episodes",
+            "columnName": "total_episodes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "error_message",
+            "columnName": "error_message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "created_at",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "started_at",
+            "columnName": "started_at",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "completed_at",
+            "columnName": "completed_at",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_registration_queue_status",
+            "unique": false,
+            "columnNames": [
+              "status"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_registration_queue_status` ON `${TABLE_NAME}` (`status`)"
+          },
+          {
+            "name": "idx_registration_queue_ncode",
+            "unique": false,
+            "columnNames": [
+              "ncode"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_registration_queue_ncode` ON `${TABLE_NAME}` (`ncode`)"
+          },
+          {
+            "name": "idx_registration_queue_created_at",
+            "unique": false,
+            "columnNames": [
+              "created_at"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_registration_queue_created_at` ON `${TABLE_NAME}` (`created_at`)"
+          }
+        ]
+      },
+      {
+        "tableName": "temp_episodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`ncode` TEXT NOT NULL, `episode_no` TEXT NOT NULL, `body` TEXT NOT NULL, `e_title` TEXT NOT NULL, `update_time` TEXT NOT NULL, `is_read` INTEGER NOT NULL, `is_bookmark` INTEGER NOT NULL, `reading_rate` REAL NOT NULL, `queue_id` INTEGER NOT NULL, PRIMARY KEY(`ncode`, `episode_no`))",
+        "fields": [
+          {
+            "fieldPath": "ncode",
+            "columnName": "ncode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "episode_no",
+            "columnName": "episode_no",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "e_title",
+            "columnName": "e_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "update_time",
+            "columnName": "update_time",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_read",
+            "columnName": "is_read",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "is_bookmark",
+            "columnName": "is_bookmark",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reading_rate",
+            "columnName": "reading_rate",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "queue_id",
+            "columnName": "queue_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "ncode",
+            "episode_no"
+          ]
+        },
+        "indices": [
+          {
+            "name": "idx_temp_episodes_ncode",
+            "unique": false,
+            "columnNames": [
+              "ncode",
+              "episode_no"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_temp_episodes_ncode` ON `${TABLE_NAME}` (`ncode`, `episode_no`)"
+          },
+          {
+            "name": "idx_temp_episodes_queue_id",
+            "unique": false,
+            "columnNames": [
+              "queue_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `idx_temp_episodes_queue_id` ON `${TABLE_NAME}` (`queue_id`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '424294516e23467832eeffd6e28dfd64')"
+    ]
+  }
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeListScreen.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import com.shunlight_library.novel_reader.api.NovelApiUtils
 import com.shunlight_library.novel_reader.api.NovelApiUtils.fetchEpisodeWithRetry
 import com.shunlight_library.novel_reader.api.NovelApiUtils.fetchNovelInfo
 import android.content.Intent
@@ -1008,21 +1009,27 @@ fun EpisodeListScreen(
                                 // 実際のIDで本文を取得
                                 val episodeBody = adapter.fetchEpisodeContent(workId, kakuyomuEpisodeId)
 
-                                // 既存エピソードを取得して更新
-                                val existingEpisode = withContext(Dispatchers.IO) {
-                                    repository.getEpisode(targetNovel.ncode, episodeNoStr)
-                                }
-
-                                if (existingEpisode != null) {
-                                    val updatedEpisode = existingEpisode.copy(body = episodeBody)
-                                    withContext(Dispatchers.IO) {
-                                        repository.insertEpisode(updatedEpisode)
-                                    }
-                                    successCount++
-                                    android.util.Log.d("EpisodeListScreen", "カクヨムエピソード修正成功: episode_no=$episodeNo, kakuyomu_id=$kakuyomuEpisodeId")
-                                } else {
-                                    android.util.Log.w("EpisodeListScreen", "既存エピソードが見つかりません: episode_no=$episodeNo")
+                                // 取得失敗・エラー本文は保存しない（エラー文の本文保存による恒久化防止）
+                                if (episodeBody.isEmpty() || episodeBody.startsWith("★HTMLページ読み込みエラー")) {
+                                    android.util.Log.w("EpisodeListScreen", "本文取得失敗のため保存をスキップ: episode_no=$episodeNo")
                                     failCount++
+                                } else {
+                                    // 既存エピソードを取得して更新
+                                    val existingEpisode = withContext(Dispatchers.IO) {
+                                        repository.getEpisode(targetNovel.ncode, episodeNoStr)
+                                    }
+
+                                    if (existingEpisode != null) {
+                                        val updatedEpisode = existingEpisode.copy(body = episodeBody)
+                                        withContext(Dispatchers.IO) {
+                                            repository.insertEpisode(updatedEpisode)
+                                        }
+                                        successCount++
+                                        android.util.Log.d("EpisodeListScreen", "カクヨムエピソード修正成功: episode_no=$episodeNo, kakuyomu_id=$kakuyomuEpisodeId")
+                                    } else {
+                                        android.util.Log.w("EpisodeListScreen", "既存エピソードが見つかりません: episode_no=$episodeNo")
+                                        failCount++
+                                    }
                                 }
                             } catch (e: Exception) {
                                 android.util.Log.e("EpisodeListScreen", "カクヨムエピソード取得エラー: episode_no=$episodeNo", e)
@@ -1619,16 +1626,20 @@ fun EpisodeListScreen(
                             .clickable(enabled = novel != null && !isNovelUpdating) {
                                 if (!isNovelUpdating) {
                                     novel?.let { novelEntity ->
-                                        val userId = novelEntity.userid
-                                        if (userId != null) {
-                                            val url = if (novelEntity.rating == 1) {
-                                                "https://xmypage.syosetu.com/$userId/"
-                                            } else {
-                                                "https://mypage.syosetu.com/$userId/"
+                                        scope.launch {
+                                            if (authorPageNeedsFetch(novelEntity)) {
+                                                Toast.makeText(context, "作者情報を取得中...", Toast.LENGTH_SHORT).show()
                                             }
-                                            onAuthorClick(url)
-                                        } else {
-                                            Toast.makeText(context, "すでになろうにいません", Toast.LENGTH_SHORT).show()
+                                            val result = withContext(Dispatchers.IO) {
+                                                resolveAuthorPageUrl(novelEntity, repository)
+                                            }
+                                            if (result != null) {
+                                                // 新規取得したIDはローカル状態にも反映（次回はネットワーク不要）
+                                                result.updatedNovel?.let { novel = it }
+                                                onAuthorClick(result.url)
+                                            } else {
+                                                Toast.makeText(context, "作者ページを取得できませんでした", Toast.LENGTH_SHORT).show()
+                                            }
                                         }
                                     }
                                 }
@@ -2038,3 +2049,67 @@ fun EpisodeItem(
 //        }
 //    }
 //}
+
+/** 作者ページ解決結果（userid を新規取得した場合は updatedNovel に反映済みエンティティが入る） */
+private data class AuthorPageResult(val url: String, val updatedNovel: NovelDescEntity?)
+
+/** 作者ページURLの解決にネットワークアクセスが必要かどうか */
+private fun authorPageNeedsFetch(novel: NovelDescEntity): Boolean {
+    val userid = novel.userid
+    return when {
+        novel.site_type == NovelSiteAdapter.SITE_TYPE_KAKUYOMU -> userid.isNullOrEmpty()
+        novel.rating == 1 -> userid.isNullOrEmpty() || !userid.startsWith("x")
+        else -> userid.isNullOrEmpty()
+    }
+}
+
+/**
+ * 作者ページURLを解決する。
+ * - カクヨム: userid（スクリーンネーム）から https://kakuyomu.jp/users/{name}。
+ *   未保存なら作品ページから取得してDBへ保存。
+ * - なろうR18: useridにキャッシュ済みのxid（x始まり）から https://xmypage.syosetu.com/{xid}/。
+ *   未取得なら作品ページからxidをスクレイプしてDBへ保存（novel18apiはuseridを返さず、
+ *   数値useridではxmypageは404になるため）。
+ * - なろう一般: userid から https://mypage.syosetu.com/{userid}/。未保存ならAPIから取得して保存。
+ */
+private suspend fun resolveAuthorPageUrl(
+    novel: NovelDescEntity,
+    repository: com.shunlight_library.novel_reader.data.repository.NovelRepository
+): AuthorPageResult? {
+    val userid = novel.userid
+    return when {
+        novel.site_type == NovelSiteAdapter.SITE_TYPE_KAKUYOMU -> {
+            if (!userid.isNullOrEmpty()) {
+                AuthorPageResult("https://kakuyomu.jp/users/$userid", null)
+            } else {
+                KakuyomuAdapter().fetchAuthorUserName(novel.ncode)?.let { name ->
+                    val updated = novel.copy(userid = name)
+                    repository.updateNovel(updated)
+                    AuthorPageResult("https://kakuyomu.jp/users/$name", updated)
+                }
+            }
+        }
+        novel.rating == 1 -> {
+            if (!userid.isNullOrEmpty() && userid.startsWith("x")) {
+                AuthorPageResult("https://xmypage.syosetu.com/$userid/", null)
+            } else {
+                NovelApiUtils.fetchR18AuthorId(novel.ncode)?.let { xid ->
+                    val updated = novel.copy(userid = xid)
+                    repository.updateNovel(updated)
+                    AuthorPageResult("https://xmypage.syosetu.com/$xid/", updated)
+                }
+            }
+        }
+        else -> {
+            if (!userid.isNullOrEmpty()) {
+                AuthorPageResult("https://mypage.syosetu.com/$userid/", null)
+            } else {
+                fetchNovelInfo(novel.ncode, isR18 = false)?.userid?.let { fetched ->
+                    val updated = novel.copy(userid = fetched)
+                    repository.updateNovel(updated)
+                    AuthorPageResult("https://mypage.syosetu.com/$fetched/", updated)
+                }
+            }
+        }
+    }
+}

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/EpisodeViewScreen.kt
@@ -126,6 +126,9 @@ fun EpisodeViewScreen(
     }
 
     LaunchedEffect(ncode, episodeNo) {
+        // 前後話ナビゲーション時に旧話の本文で描画されるのを防ぐ
+        // （nullの間はローディング表示になり、新データ到着時にWebView/縦書きViewが再生成される）
+        episode = null
 
         scrollState.scrollTo(0)
         scope.launch {
@@ -133,6 +136,10 @@ fun EpisodeViewScreen(
                 // エピソード情報の取得
                 episode = repository.getEpisode(ncode, episodeNo)
                 novel = repository.getNovelByNcode(ncode)
+
+                // 縦書き進捗の初期値を保存済みの値に合わせる
+                // （開いた直後に戻った場合に0で上書きされるのを防ぐ）
+                vjapReadingRate = episode?.reading_rate ?: 0f
 
                 // 削除済み作品の検出
                 if (novel == null) {
@@ -667,23 +674,27 @@ fun EpisodeViewScreen(
                         }
                     } else {
                         // 横書きモード: WebViewでHTML表示
-                        EnhancedHtmlRubyWebView(
-                            htmlContent = episode!!.body,
-                            fontSize = fontSize,
-                            rubyFontSize = (fontSize * 0.6).toInt(),
-                            backgroundColor = if (useDefaultBackground) null else backgroundColor,
-                            fontColor = fontColor,
-                            fontFamily = fontFamily,
-                            isCustomFont = isCustomFont,
-                            customFontPath = customFontPath,
-                            textOrientation = textOrientation,
-                            autoRubyEnabled = autoRubyEnabled,
-                            ncode = ncode,
-                            episodeNo = episodeNo,
-                            savedReadingRate = episode!!.reading_rate,
-                            modifier = Modifier.padding(bottom = 32.dp),
-                            onWebViewCreated = { webView = it }
-                        )
+                        // key()で話ごとにWebViewを再生成し、JSブリッジ（WebViewScrollInterface）が
+                        // 古いepisodeNoを保持して別の話の進捗を上書きするのを防ぐ
+                        key(ncode, episodeNo) {
+                            EnhancedHtmlRubyWebView(
+                                htmlContent = episode!!.body,
+                                fontSize = fontSize,
+                                rubyFontSize = (fontSize * 0.6).toInt(),
+                                backgroundColor = if (useDefaultBackground) null else backgroundColor,
+                                fontColor = fontColor,
+                                fontFamily = fontFamily,
+                                isCustomFont = isCustomFont,
+                                customFontPath = customFontPath,
+                                textOrientation = textOrientation,
+                                autoRubyEnabled = autoRubyEnabled,
+                                ncode = ncode,
+                                episodeNo = episodeNo,
+                                savedReadingRate = episode!!.reading_rate,
+                                modifier = Modifier.padding(bottom = 32.dp),
+                                onWebViewCreated = { webView = it }
+                            )
+                        }
                     }
                 }
             }
@@ -991,6 +1002,7 @@ fun EnhancedHtmlRubyWebView(
                 )
                 // HTMLをロード
                 loadDataWithBaseURL(null, formattedHtml, "text/html", "UTF-8", null)
+                tag = formattedHtml
             }
         },
         update = { view ->
@@ -1000,7 +1012,12 @@ fun EnhancedHtmlRubyWebView(
             } else {
                 WebSettings.LayoutAlgorithm.TEXT_AUTOSIZING
             }
-            view.loadDataWithBaseURL(null, formattedHtml, "text/html", "UTF-8", null)
+            // HTMLが実際に変わった場合のみ再ロード
+            // （無条件に再ロードすると再コンポーズのたびにスクロール位置がリセットされる）
+            if (view.tag != formattedHtml) {
+                view.loadDataWithBaseURL(null, formattedHtml, "text/html", "UTF-8", null)
+                view.tag = formattedHtml
+            }
         },
         onRelease = { view ->
             view.stopLoading()

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/WebViewScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/WebViewScreen.kt
@@ -52,7 +52,6 @@ fun WebViewScreen(
     var webView by remember { mutableStateOf<WebView?>(null) }
     var canGoBack by remember { mutableStateOf(false) }
     var canGoForward by remember { mutableStateOf(false) }
-    var currentLoadingUrl by remember { mutableStateOf("") }
     var currentUrl by remember { mutableStateOf(url) }
 
     // ダイアログの表示状態
@@ -125,7 +124,6 @@ fun WebViewScreen(
                 super.onPageFinished(view, loadedUrl)
                 canGoBack = view.canGoBack()
                 canGoForward = view.canGoForward()
-                currentLoadingUrl = loadedUrl
                 currentUrl = loadedUrl
 
                 // target="_blank"リンクを修正するJavaScriptを実行
@@ -221,6 +219,16 @@ fun WebViewScreen(
 
             override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
                 Log.d("WebViewScreen", "shouldOverrideUrlLoading called with URL: $url")
+                // http(s)以外のスキーム（mailto:, intent://等）は外部アプリへ委譲
+                // （WebViewで読み込むと net::ERR_UNKNOWN_URL_SCHEME になるため）
+                if (!url.startsWith("http://") && !url.startsWith("https://")) {
+                    try {
+                        view.context.startActivity(Intent(Intent.ACTION_VIEW, android.net.Uri.parse(url)))
+                    } catch (e: Exception) {
+                        Log.w("WebViewScreen", "外部スキームを開けません: $url")
+                    }
+                    return true
+                }
                 view.loadUrl(url)
                 return true
             }
@@ -231,6 +239,7 @@ fun WebViewScreen(
 
                 // R18サイトへのアクセス時にCookieを設定
                 if (url.contains("novel18.syosetu.com") ||
+                    url.contains("xmypage.syosetu.com") ||
                     url.contains("noc.syosetu.com") ||
                     url.contains("mid.syosetu.com") ||
                     url.contains("mnlt.syosetu.com") ||
@@ -439,6 +448,7 @@ fun WebViewScreen(
                         val cookieManager = CookieManager.getInstance()
                         cookieManager.setAcceptCookie(true)
                         cookieManager.setCookie("https://novel18.syosetu.com", "over18=yes")
+                        cookieManager.setCookie("https://xmypage.syosetu.com", "over18=yes")
                         cookieManager.setCookie("https://noc.syosetu.com", "over18=yes")
                         cookieManager.setCookie("https://mid.syosetu.com", "over18=yes")
                         cookieManager.setCookie("https://mnlt.syosetu.com", "over18=yes")
@@ -449,13 +459,9 @@ fun WebViewScreen(
                         webView = this
                     }
                 },
-                update = { view ->
-                    if (currentLoadingUrl.isEmpty() || currentLoadingUrl == url) {
-                        view.loadUrl(url)
-                        currentLoadingUrl = url
-                        currentUrl = url
-                    }
-                },
+                // 初期ロードはfactoryで実施済み。updateで再ロードすると
+                // 再コンポーズのたびにページがリロードされるため何もしない
+                update = { },
                 onRelease = { view ->
                     view.stopLoading()
                     view.destroy()

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/api/NovelApiUtils.kt
@@ -237,6 +237,38 @@ object NovelApiUtils {
         return null
     }
 
+    /**
+     * R18作品の作者マイページID（xid、例: "x9360cn"）を取得する
+     *
+     * novel18api は userid を返さず、R18作者ページは
+     * https://xmypage.syosetu.com/{xid}/ 形式（数値useridでは404）のため、
+     * 作品ページの作者リンクから xid を抽出する。
+     *
+     * @param ncode R18小説のNコード
+     * @return xid（取得失敗時はnull）
+     */
+    suspend fun fetchR18AuthorId(ncode: String): String? = withContext(Dispatchers.IO) {
+        try {
+            val url = "https://novel18.syosetu.com/${ncode.lowercase()}/"
+            val doc = Jsoup.connect(url)
+                .userAgent(API_USER_AGENTS.random())
+                .cookie("over18", "yes")
+                .timeout(15000)
+                .get()
+            val href = doc.select("a[href*=xmypage.syosetu.com]").firstOrNull()?.attr("href")
+            if (href == null) {
+                Log.w(TAG, "R18作者リンクが見つかりません: $ncode")
+                return@withContext null
+            }
+            Regex("xmypage\\.syosetu\\.com/([^/?#]+)").find(href)?.groupValues?.get(1)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "R18作者ID取得エラー: $ncode - ${e.message}")
+            null
+        }
+    }
+
     private suspend fun requestNovelInfo(url: String, userAgent: String): NovelApiInfo? {
         // レート制限を適用
         applyApiRateLimit()
@@ -541,7 +573,7 @@ object NovelApiUtils {
 
                     val currentDate = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault()).format(Date())
 
-                    return@withContext if (body.isNotEmpty()) {
+                    return@withContext if (body.isNotEmpty() && !body.startsWith("★HTMLページ読み込みエラー")) {
                         EpisodeEntity(
                             ncode = ncode,
                             episode_no = episodeNo,
@@ -552,7 +584,7 @@ object NovelApiUtils {
                             is_bookmark = 0
                         )
                     } else {
-                        Log.e(TAG, "カクヨムエピソード本文が空です: workId=$workId, episodeId=$kakuyomuEpisodeId")
+                        Log.e(TAG, "カクヨムエピソード本文が空またはエラーです: workId=$workId, episodeId=$kakuyomuEpisodeId")
                         null
                     }
                 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/data/adapter/KakuyomuAdapter.kt
@@ -124,7 +124,7 @@ class KakuyomuAdapter : NovelSiteAdapter {
         val episodesWithBody = episodesWithoutBody.map { episode ->
             // episode.episode_no は連番（1, 2, 3...）なので、キャッシュから実際のIDを取得
             val actualEpisodeId = cachedMappings[episode.episode_no.toInt()] ?: episode.episode_no
-            val episodeBody = fetchEpisodeContent(workId, actualEpisodeId)
+            val episodeBody = normalizeEpisodeBody(fetchEpisodeContent(workId, actualEpisodeId))
             episode.copy(body = episodeBody)
         }
 
@@ -192,7 +192,7 @@ class KakuyomuAdapter : NovelSiteAdapter {
             // 1話ずつ取得→保存（メモリリーク防止）
             episodesWithoutBody.forEachIndexed { index, episode ->
                 val actualEpisodeId = cachedMappings[episode.episode_no.toInt()] ?: episode.episode_no
-                val episodeBody = fetchEpisodeContent(workId, actualEpisodeId)
+                val episodeBody = normalizeEpisodeBody(fetchEpisodeContent(workId, actualEpisodeId))
                 val episodeWithBody = episode.copy(body = episodeBody)
 
                 // 1話ずつ保存
@@ -231,7 +231,7 @@ class KakuyomuAdapter : NovelSiteAdapter {
             // 旧方式：全話をメモリに保持（後方互換性のため残す）
             val episodesWithBody = episodesWithoutBody.map { episode ->
                 val actualEpisodeId = cachedMappings[episode.episode_no.toInt()] ?: episode.episode_no
-                val episodeBody = fetchEpisodeContent(workId, actualEpisodeId)
+                val episodeBody = normalizeEpisodeBody(fetchEpisodeContent(workId, actualEpisodeId))
                 episode.copy(body = episodeBody)
             }
 
@@ -591,6 +591,9 @@ class KakuyomuAdapter : NovelSiteAdapter {
             }
         }
 
+        // 作者スクリーンネーム（作者ページURL https://kakuyomu.jp/users/{name} 用）
+        val authorUserName = extractAuthorUserName(apolloState, workData, doc)
+
         if (author.isEmpty()) {
             // 新しいHTML構造: partialGiftWidgetActivityName
             author = doc.select("div.partialGiftWidgetActivityName a").text()
@@ -784,7 +787,7 @@ class KakuyomuAdapter : NovelSiteAdapter {
             last_update_date = lastUpdateDate,  // サイト上の最終更新日
             total_ep = totalEp,
             general_all_no = 0,  // カクヨムにはこの情報がない
-            userid = null,  // HTMLから抽出困難
+            userid = authorUserName,  // 作者スクリーンネーム（kakuyomu.jp/users/{name}）
             noveltype = if (totalEp == 1) 2 else 1,  // 1話のみなら短編、それ以外は連載
             length = null,  // HTMLから抽出困難
             updated_at = lastUpdateDate,  // サイト上の最終更新日時
@@ -795,6 +798,61 @@ class KakuyomuAdapter : NovelSiteAdapter {
             end_flag = endFlag
         )
     }
+
+    /**
+     * 作者スクリーンネーム（kakuyomu.jp/users/{name} のname部分）を抽出する
+     */
+    private fun extractAuthorUserName(apolloState: JSONObject?, workData: JSONObject?, doc: Document): String? {
+        // Apollo state（最優先）: Work の author 参照から UserAccount の name を取得
+        if (workData != null && apolloState != null) {
+            val refKey = workData.optJSONObject("author")?.optString("__ref") ?: ""
+            if (refKey.isNotEmpty()) {
+                val name = apolloState.optJSONObject(refKey)?.optString("name") ?: ""
+                if (name.isNotEmpty()) return name
+            }
+        }
+        // フォールバック: 作品ページの作者リンク（href="/users/{name}"）
+        val href = doc.select("a[href^=/users/]").firstOrNull()?.attr("href")
+        if (href != null) {
+            val name = href.removePrefix("/users/").substringBefore("/").substringBefore("?")
+            if (name.isNotEmpty()) return name
+        }
+        return null
+    }
+
+    /**
+     * 作品ページから作者スクリーンネームを取得する（作者ページ遷移用）
+     *
+     * @param novelId カクヨムの作品IDまたはPseudo-Ncode
+     * @return スクリーンネーム（取得失敗時はnull）
+     */
+    suspend fun fetchAuthorUserName(novelId: String): String? = withContext(Dispatchers.IO) {
+        val workId = if (PseudoNcodeGenerator.isKakuyomuNcode(novelId)) {
+            PseudoNcodeGenerator.extractKakuyomuWorkId(novelId)
+        } else {
+            novelId
+        }
+        try {
+            applyRateLimit()
+            val html = performHttpRequest(generateWebUrl(workId))
+            val doc = Jsoup.parse(html)
+            val (apolloState, workData) = extractNextDataJson(doc, workId)
+            extractAuthorUserName(apolloState, workData, doc)
+        } catch (e: Exception) {
+            AppLogger.e("KakuyomuAdapter", "作者スクリーンネーム取得エラー: $workId", e)
+            null
+        }
+    }
+
+    /**
+     * 取得失敗時のエラー文字列を空文字に正規化する
+     *
+     * エラー文を本文として保存すると body が非空になり、body_empty ベースの
+     * エラースキャンを恒久的にすり抜ける。空文字にすることで insertEpisode の
+     * マージが既存本文を保護し、欠落スキャンでも検出可能になる。
+     */
+    private fun normalizeEpisodeBody(body: String): String =
+        if (body.startsWith("★HTMLページ読み込みエラー")) "" else body
 
     /**
      * HTMLからエピソード一覧を抽出（TOC情報のみ、本文は含まない）

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/manager/RegistrationQueueManager.kt
@@ -484,7 +484,10 @@ object RegistrationQueueManager {
             val actualEpisodeId = mappings[epNo] ?: episode.episode_no
 
             // エピソード本文を取得
-            val episodeBody = adapter.fetchEpisodeContent(workId, actualEpisodeId)
+            // 取得失敗時のエラー文字列は空文字に正規化（body_empty ベースの
+            // エラースキャンで後から検出・再取得できるようにする）
+            val rawBody = adapter.fetchEpisodeContent(workId, actualEpisodeId)
+            val episodeBody = if (rawBody.startsWith("★HTMLページ読み込みエラー")) "" else rawBody
             val episodeWithBody = episode.copy(body = episodeBody)
 
             // 一時テーブルに保存

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/components/VjapVerticalTextView.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/ui/components/VjapVerticalTextView.kt
@@ -12,11 +12,33 @@ import com.shunlight_library.novel_reader.utils.VjapTextConverter
 import jp.taizan.android.vjap.VTextLayout
 
 /**
+ * 適用済み設定と読書位置の追跡。
+ * 再コンポーズによる不要な再レイアウト（＝ページ位置の喪失）を防ぎ、
+ * 設定変更時はページ計算完了後に直前の位置を復元する。
+ */
+private class VjapAppliedState(initialRate: Float) {
+    var fontSizePx = -1
+    var fontColor = ""
+    var backgroundColor = ""
+    var fontPath: String? = null
+    var content: String? = null
+    var title: String? = null
+
+    /** 次のページ計算完了時に復元する進捗率 */
+    var restoreRate = initialRate
+
+    /** 現在の進捗率（ページ送りのたびに更新） */
+    var currentRate = initialRate
+}
+
+/**
  * vjapライブラリを使用した縦書きテキスト表示コンポーザブル。
  *
  * - fontSizeはspで受け取り、内部でpx換算してvjapに渡す
  * - スワイプ無効・タップでページ送りのページ分割モードで動作
  * - 読書進捗はページ番号/総ページ数（0.0〜1.0）で保存・復元
+ * - ページをめくるたびに onReadingRateChanged で進捗率を通知
+ * - フォントサイズ・色・フォントの変更時も現在の読書位置を維持する
  */
 @Composable
 fun VjapVerticalTextView(
@@ -34,7 +56,7 @@ fun VjapVerticalTextView(
         VjapTextConverter.convertHtmlToAozora(htmlContent)
     }
 
-    val savedRateRef = remember(savedReadingRate) { savedReadingRate }
+    val applied = remember { VjapAppliedState(savedReadingRate) }
 
     AndroidView(
         factory = { context ->
@@ -47,6 +69,32 @@ fun VjapVerticalTextView(
                 // スワイプ無効 → タップでページ送りのページ分割モード
                 setScrollDisabled(true)
 
+                // ページ計算完了後に保存済み（または設定変更直前の）ページを復元
+                setOnReadyListener { totalPage ->
+                    if (totalPage > 0 && applied.restoreRate > 0f) {
+                        val targetPage = Math.round(applied.restoreRate * totalPage).coerceIn(1, totalPage)
+                        setCurrentPage(targetPage)
+                    }
+                    val rate = if (totalPage > 0) getCurrentPage().toFloat() / totalPage else 0f
+                    applied.currentRate = rate.coerceIn(0f, 1f)
+                    onReadingRateChanged(applied.currentRate)
+                }
+
+                // ページ送りのたびに進捗率を通知（読書位置の保存用）
+                setOnPageChangedListener { page, totalPage ->
+                    if (totalPage > 0) {
+                        applied.currentRate = (page.toFloat() / totalPage).coerceIn(0f, 1f)
+                        onReadingRateChanged(applied.currentRate)
+                    }
+                }
+
+                setOnPageEndListener {
+                    if (getTotalPage() > 0) {
+                        applied.currentRate = 1f
+                        onReadingRateChanged(1f)
+                    }
+                }
+
                 setFontSize(fontSizePx)
                 try {
                     setColor(fontColor, backgroundColor)
@@ -56,39 +104,53 @@ fun VjapVerticalTextView(
                 if (!customFontPath.isNullOrEmpty()) {
                     vTextView.setFont(customFontPath)
                 }
-
-                // ページ計算完了後に保存済みページを復元
-                setOnReadyListener { totalPage ->
-                    if (totalPage > 0 && savedRateRef > 0f) {
-                        val targetPage = (savedRateRef * totalPage).toInt().coerceIn(1, totalPage)
-                        setCurrentPage(targetPage)
-                    }
-                    val rate = if (totalPage > 0) getCurrentPage().toFloat() / totalPage.toFloat() else 0f
-                    onReadingRateChanged(rate.coerceIn(0f, 1f))
-                }
-
-                setOnPageEndListener {
-                    val total = getTotalPage()
-                    if (total > 0) onReadingRateChanged(1f)
-                }
-
                 initContent(episodeTitle, aozoraText)
+
+                applied.fontSizePx = fontSizePx
+                applied.fontColor = fontColor
+                applied.backgroundColor = backgroundColor
+                applied.fontPath = customFontPath
+                applied.content = aozoraText
+                applied.title = episodeTitle
             }
         },
         update = { layout ->
-            // フォントサイズ・色など設定変更のみ反映（コンテンツは変わらない）
             val density = layout.resources.displayMetrics.scaledDensity
             val fontSizePx = (fontSize * density).toInt().coerceAtLeast(12)
-            layout.setFontSize(fontSizePx)
-            try {
-                layout.setColor(fontColor, backgroundColor)
-            } catch (e: Exception) {
-                layout.setColor("#000000", "#FFFFFF")
-            }
-            if (!customFontPath.isNullOrEmpty()) {
-                layout.vTextView.setFont(customFontPath)
-            } else {
-                layout.vTextView.setFont(null)
+
+            val contentChanged = applied.content != aozoraText || applied.title != episodeTitle
+            val settingsChanged = applied.fontSizePx != fontSizePx ||
+                    applied.fontColor != fontColor ||
+                    applied.backgroundColor != backgroundColor ||
+                    applied.fontPath != customFontPath
+
+            // 変更がある場合のみ適用（無条件に呼ぶと再レイアウトで読書位置が失われる）
+            if (contentChanged || settingsChanged) {
+                // 再レイアウト後の復元位置: 別エピソードなら保存済み位置、設定変更なら現在位置
+                applied.restoreRate = if (contentChanged) savedReadingRate else applied.currentRate
+
+                if (applied.fontSizePx != fontSizePx) {
+                    layout.setFontSize(fontSizePx)
+                    applied.fontSizePx = fontSizePx
+                }
+                if (applied.fontColor != fontColor || applied.backgroundColor != backgroundColor) {
+                    try {
+                        layout.setColor(fontColor, backgroundColor)
+                    } catch (e: Exception) {
+                        layout.setColor("#000000", "#FFFFFF")
+                    }
+                    applied.fontColor = fontColor
+                    applied.backgroundColor = backgroundColor
+                }
+                if (applied.fontPath != customFontPath) {
+                    layout.vTextView.setFont(if (customFontPath.isNullOrEmpty()) null else customFontPath)
+                    applied.fontPath = customFontPath
+                }
+                if (contentChanged) {
+                    layout.initContent(episodeTitle, aozoraText)
+                    applied.content = aozoraText
+                    applied.title = episodeTitle
+                }
             }
         },
         modifier = modifier

--- a/Novel_reader/app/src/main/java/jp/taizan/android/vjap/VTextLayout.java
+++ b/Novel_reader/app/src/main/java/jp/taizan/android/vjap/VTextLayout.java
@@ -56,6 +56,7 @@ public class VTextLayout extends RelativeLayout {
 
     OnPageEndListener onPageEndListener = null;
     OnReadyListener onReadyListener = null;
+    OnPageChangedListener onPageChangedListener = null;
 
     private float density;
 
@@ -204,6 +205,10 @@ public class VTextLayout extends RelativeLayout {
             public void onPageSelected(int position) {
                 currentPage = position;
                 updatePageText();
+
+                if (onPageChangedListener != null) {
+                    onPageChangedListener.onPageChanged(position, vTextView.getTotalPage());
+                }
 
                 if (position >= viewPager.totalPage && onPageEndListener != null) {
                     onPageEndListener.onPageEnd();
@@ -375,6 +380,18 @@ public class VTextLayout extends RelativeLayout {
 
     public void setOnReadyListener(OnReadyListener listener) {
         this.onReadyListener = listener;
+    }
+
+    /**
+     * Called whenever the visible page changes (1-indexed).
+     * totalPage may be -1 while page calculation is in progress.
+     */
+    public interface OnPageChangedListener {
+        void onPageChanged(int page, int totalPage);
+    }
+
+    public void setOnPageChangedListener(OnPageChangedListener listener) {
+        this.onPageChangedListener = listener;
     }
 
     public void setVirtical(boolean isVirtical) {

--- a/Novel_reader/app/src/main/java/jp/taizan/android/vjap/VTextView.java
+++ b/Novel_reader/app/src/main/java/jp/taizan/android/vjap/VTextView.java
@@ -19,9 +19,21 @@ import android.view.View;
 public class VTextView extends View {
 
     private static final int FONT_COLOR = Color.BLACK;
-    private static final int TOP_SPACE = 18;
-    private static final int BOTTOM_SPACE = 18;
+    private static final int TOP_SPACE = 18;     // dp
+    private static final int BOTTOM_SPACE = 18;  // dp
     public static final int MAX_PAGE = 1024;
+
+    // 行頭禁則文字（行頭に来てはならない文字。前の文字での改行を抑止し、ぶら下げで処理する）
+    private static final String LINE_HEAD_PROHIBITED =
+            "。、，．」』）)］]｝}〉》】〕＞>！？!?‼⁇⁈⁉…‥ーｰ～〜ゝゞヽヾ々" +
+            "ぁぃぅぇぉっゃゅょゎァィゥェォッャュョヮヵヶ：；:;.,";
+
+    // 行末禁則文字（行末に来てはならない文字。先に改行してから描画する）
+    private static final String LINE_END_PROHIBITED = "「『（(［[｛{〈《【〔＜<“";
+
+    // 密度スケール済み余白（init で設定）
+    private float topSpace = TOP_SPACE;
+    private float bottomSpace = BOTTOM_SPACE;
 
     int TITLE_SIZE = 48;
     int FONT_SIZE = 32;
@@ -66,6 +78,9 @@ public class VTextView extends View {
 
     private void init(Context context) {
         mContext = context;
+        float density = context.getResources().getDisplayMetrics().density;
+        topSpace = TOP_SPACE * density;
+        bottomSpace = BOTTOM_SPACE * density;
         mFace = Typeface.create(Typeface.DEFAULT, Typeface.NORMAL);
         setFontSize(FONT_SIZE);
         rubyStyle.lineSpace = bodyStyle.lineSpace;
@@ -197,7 +212,7 @@ public class VTextView extends View {
     boolean goNextLine(PointF pos, TextStyle type, float spaceRate) {
         if (virtical) {
             pos.x -= type.lineSpace * spaceRate;
-            pos.y = TOP_SPACE + type.fontSpace;
+            pos.y = topSpace + type.fontSpace;
             if (pos.x > 0) {
                 return true;
             } else {
@@ -205,8 +220,8 @@ public class VTextView extends View {
             }
         } else {
             pos.y += type.lineSpace * spaceRate;
-            pos.x = TOP_SPACE;
-            if (pos.y < height - TOP_SPACE) {
+            pos.x = topSpace;
+            if (pos.y < height - topSpace) {
                 return true;
             } else {
                 return false;
@@ -214,17 +229,26 @@ public class VTextView extends View {
         }
     }
 
-    boolean goNext(String s, PointF pos, TextStyle type, boolean lineChangable) {
-        boolean newLine = false;
+    /** 現在位置が行の最終マスか（この位置に描いた次の文字は行内に収まらない） */
+    boolean isLineFull(PointF pos, TextStyle type) {
         if (virtical) {
-            if (pos.y + type.fontSpace > height - BOTTOM_SPACE) {
-                newLine = true;
-            }
+            return pos.y + type.fontSpace > height - bottomSpace;
         } else {
-            if (pos.x + type.fontSpace > width - BOTTOM_SPACE - type.fontSpace) {
-                newLine = true;
-            }
+            return pos.x + type.fontSpace > width - bottomSpace - type.fontSpace;
         }
+    }
+
+    /** ページ内に次の行を確保できるか（goNextLine が成功するか） */
+    boolean canGoNextLine(PointF pos, TextStyle type, float spaceRate) {
+        if (virtical) {
+            return pos.x - type.lineSpace * spaceRate > 0;
+        } else {
+            return pos.y + type.lineSpace * spaceRate < height - topSpace;
+        }
+    }
+
+    boolean goNext(String s, PointF pos, TextStyle type, boolean lineChangable) {
+        boolean newLine = isLineFull(pos, type);
 
         if (newLine && lineChangable) {
             return goNextLine(pos, type, 1);
@@ -242,9 +266,9 @@ public class VTextView extends View {
     void initPos(PointF pos) {
         if (virtical) {
             pos.x = width - bodyStyle.lineSpace;
-            pos.y = TOP_SPACE + bodyStyle.fontSpace;
+            pos.y = topSpace + bodyStyle.fontSpace;
         } else {
-            pos.x = TOP_SPACE;
+            pos.x = topSpace;
             pos.y = bodyStyle.lineSpace;
         }
     }
@@ -269,7 +293,7 @@ public class VTextView extends View {
             if (state.pos.y - state.rubyStart.y > 0) {
                 res.y -= 0.5 * (state.rubyText.length() * rubyStyle.fontSpace - (state.pos.y - state.rubyStart.y));
             }
-            if (res.y < TOP_SPACE) res.y = TOP_SPACE;
+            if (res.y < topSpace) res.y = topSpace;
         } else {
             res.x = state.rubyStart.x;
             res.y = state.rubyStart.y - bodyStyle.fontSpace;
@@ -455,6 +479,13 @@ public class VTextView extends View {
         if (state.str.equals("\n")) {
             return this.goNextLine(state.pos, style, 1);
         }
+
+        // 行末禁則: 開き括弧等が行の最終マスに来る場合は先に改行してから描画する
+        if (LINE_END_PROHIBITED.contains(state.str)
+                && isLineFull(state.pos, style) && canGoNextLine(state.pos, style, 1)) {
+            goNextLine(state.pos, style, 1);
+        }
+
         this.drawChar(canvas, state.str, state.pos, style, state.isDrawEnable);
 
         if (!this.goNext(state.str, state.pos, style, checkLineChangable(state))) {
@@ -471,15 +502,8 @@ public class VTextView extends View {
     boolean checkLineChangable(CurrentState state) {
         if (!state.lineChangable) {
             state.lineChangable = true;
-        } else if (state.sAfter.equals("。") || state.sAfter.equals("、")
-                || state.sAfter.equals("」") || state.sAfter.equals("』")
-                || state.sAfter.equals(")") || state.sAfter.equals("）")
-                || state.sAfter.equals("]") || state.sAfter.equals("］")
-                || state.sAfter.equals("}") || state.sAfter.equals("｝")
-                || state.sAfter.equals("〉") || state.sAfter.equals("】")
-                || state.sAfter.equals("〕")
-                || state.sAfter.equals("，") || state.sAfter.equals("．")
-                || state.sAfter.equals(".") || state.sAfter.equals(",")) {
+        } else if (!state.sAfter.isEmpty() && LINE_HEAD_PROHIBITED.contains(state.sAfter)) {
+            // 行頭禁則文字が次に来る場合は改行を抑止（ぶら下げ処理）
             state.lineChangable = false;
         }
         return state.lineChangable;


### PR DESCRIPTION
## 概要
縦書き表示のブラッシュアップ、R18・カクヨム作品で作者ページに飛べない不具合の解決、その他のバグ修正。バージョンを 2.0.14 → 2.0.15 (versionCode 215) に更新。

## 作者ページ遷移の不具合修正（R18・カクヨム）
実APIリクエストで根本原因を検証したうえで修正。
- **R18作品**: `novel18api` は `userid` を返さず、R18作者ページは数値IDでは404で `xmypage.syosetu.com/{xid}/`（例 `x9360cn`）形式が必要。作品ページから `xid` をスクレイプする `NovelApiUtils.fetchR18AuthorId()` を新設。
- **カクヨム作品**: `userid` が常に `null` だったのが原因。Apollo state の `UserAccount.name` から作者スクリーンネームを取得し `kakuyomu.jp/users/{name}` を生成（`KakuyomuAdapter.fetchAuthorUserName`、`parseNovelInfo` でも保存）。
- 解決したIDは `repository.updateNovel` で永続化し次回以降はネットワーク不要。`site_type`/`rating` で分岐する `resolveAuthorPageUrl` に集約。
- `WebViewScreen` に `xmypage.syosetu.com` の `over18` Cookie を追加。

## 縦書きモードのブラッシュアップ
- `VTextLayout` に `OnPageChangedListener` を追加（ページ送りごとに進捗率 page/totalPage を保存。従来は開いた時と読了時のみ）。
- `VjapVerticalTextView` の `update` を差分適用化（無条件 `setFontSize/setColor` による再レイアウト・ページ喪失を防止、フォント変更時は直前位置を復元）。
- `VTextView` の行頭禁則拡充（小書き仮名・`ー〜…‥！？：；` 等＋ぶら下げ）、開き括弧の行末禁則を追加、余白を密度スケール化（18dp）。測定パスと描画パスでページネーションが決定的に一致することを検証。

## その他のバグ修正
- **前後話で本文が切り替わらない**（縦書き）: `LaunchedEffect` 先頭で `episode = null` リセット。
- **進捗が別の話に上書きされる**（横書き）: `EnhancedHtmlRubyWebView` を `key(ncode, episodeNo)` で再生成し、JSブリッジのepisodeNo固定を解消。WebViewの再ロードはタグ比較で変更時のみ。
- **エラー本文の恒久化防止**: `★HTMLページ読み込みエラー` の本文保存を全 `fetchEpisodeContent` 保存経路で防止（EpisodeListScreenのエラー修正、KakuyomuAdapter内部3経路、RegistrationQueueManager初回登録、NovelApiUtils単話取得）。
- **WebView多重リロード**: `update` での再ロードを廃止（再コンポーズのたびにページがリセットされるバグ）。`mailto:` 等の非http(s)スキームは外部アプリへ委譲。

## 検証
- `./gradlew compileDebugKotlin compileDebugJavaWithJavac` → BUILD SUCCESSFUL
- `./gradlew testDebugUnitTest` → 全93テストパス（failures/errors=0）
- 並列調査ワークフローで問題を特定し、リスクの高い箇所（vjap禁則の決定性、`episode=null`時の進捗保存、WebView遷移の回帰、全fetchEpisodeContent呼び出し元）を個別検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)