### PR TITLE
v2.0.19: 短編除外のSyosetu限定化・完結フラグ伝播・スキーマ16.json修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,8 +4,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 📖 Quick Reference
 
-### Current State (2026-06-14)
-- **Version**: 2.0.18 (versionCode: 218)
+### Current State (2026-06-15)
+- **Version**: 2.0.19 (versionCode: 219)
 - **Database**: Version 17 with 9 tables + performance indices
 - **Supported Sites**: Syosetu (なろう小説) + Kakuyomu (カクヨム)
 - **Architecture**: Clean + MVVM + Repository + Adapter Pattern
@@ -30,7 +30,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Quick Links to Documentation
 - Architecture details → [Architecture Overview](#architecture-overview)
-- Database schema → [Database Schema (Version 16)](#database-schema-version-16)
+- Database schema → [Database Schema (Version 17)](#database-schema-version-17)
 - Performance optimization → [Performance Optimizations](#performance-optimizations)
 - Multi-site support → [Multi-Site Architecture](#multi-site-architecture)
 - API specifications → [なろう小説API仕様](#なろう小説api仕様), [カクヨムダウンロードプロトコル](#カクヨムダウンロードプロトコル)
@@ -298,7 +298,7 @@ Use `SettingsStore` for persistent configuration with DataStore.
 - v11→v12: **Performance optimization** - Added indices for sorting/filtering (total_ep, author, title, is_read, is_bookmark) and composite indices (site_type+is_favorite, ncode+is_read, ncode+is_bookmark)
 - v12→v15: Various feature additions (see git history)
 - v15→v16: Added `sub_site`, `end_flag`, `last_checked_at` to novels_descs; added indices for sub_site, end_flag, last_checked_at; initialized sub_site for existing records
-- v16→v17: ImageCacheEntityのインデックス定義同期（物理スキーマ変更なし、identity hash修正）
+- v16→v17: `image_cache`に`idx_image_cache_hash`インデックスを追加（ImageCacheEntityがv2.0.7で宣言済みだったがマイグレーション未整備だった不整合を解消）。エクスポート済み16.jsonはインデックス無しの正しいv16スキーマに再生成
 
 #### Tables (9 total)
 1. **`novels_descs`** - Novel metadata
@@ -516,7 +516,7 @@ val episodes = adapter.fetchEpisodeList(novel.ncode)
 4. **Navigation**: Use NavigationManager for navigation to maintain proper back stack
 5. **R18 Content**: Handle R18 content appropriately with dialog-based site selection
 6. **Reading Progress**: Maintain reading progress, bookmark functionality, and reading rate in EpisodeViewScreen
-7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 2.0.0 → 2.0.1) when making any code changes in `Novel_reader/app/build.gradle.kts`. Current version: 2.0.18 (versionCode 218).
+7. **Version Management**: Always increment both `versionCode` by +1 and `versionName` patch version (e.g., 2.0.0 → 2.0.1) when making any code changes in `Novel_reader/app/build.gradle.kts`. Current version: 2.0.19 (versionCode 219).
 8. **Commit Messages**: Always write commit messages in Japanese
 9. **Incremental Episode Saving**: When fetching episodes (both Kakuyomu and Syosetu), always fetch and save one episode at a time. Never fetch all episodes into memory first - instead use: fetch episode 1 → save to DB → fetch episode 2 → save to DB, etc. This applies to all re-download, update, and error-fix operations.
 10. **Multi-Site Support**: Use the Adapter pattern for site-specific logic. Never hardcode site-specific behavior outside of adapter implementations.

--- a/Novel_reader/app/build.gradle.kts
+++ b/Novel_reader/app/build.gradle.kts
@@ -16,8 +16,8 @@ android {
         applicationId = "com.shunlight_library.novel_reader"
         minSdk = 21
         targetSdk = 34
-        versionCode = 218
-        versionName = "2.0.18"
+        versionCode = 219
+        versionName = "2.0.19"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/Novel_reader/app/schemas/com.shunlight_library.novel_reader.data.database.NovelDatabase/16.json
+++ b/Novel_reader/app/schemas/com.shunlight_library.novel_reader.data.database.NovelDatabase/16.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 16,
-    "identityHash": "424294516e23467832eeffd6e28dfd64",
+    "identityHash": "743ab6feac5258ae9dd919926e293838",
     "entities": [
       {
         "tableName": "episodes",
@@ -547,18 +547,7 @@
           "columnNames": [
             "hash"
           ]
-        },
-        "indices": [
-          {
-            "name": "idx_image_cache_hash",
-            "unique": false,
-            "columnNames": [
-              "hash"
-            ],
-            "orders": [],
-            "createSql": "CREATE INDEX IF NOT EXISTS `idx_image_cache_hash` ON `${TABLE_NAME}` (`hash`)"
-          }
-        ]
+        }
       },
       {
         "tableName": "episode_mapping",
@@ -820,7 +809,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '424294516e23467832eeffd6e28dfd64')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '743ab6feac5258ae9dd919926e293838')"
     ]
   }
 }

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/UpdateInfoScreen.kt
@@ -541,9 +541,13 @@ fun UpdateInfoScreen(
                                 // 更新対象の小説を取得
                                 var novelsForUpdate = repository.getNovelsForUpdate()
                                 // 短編は新規エピソードが増えないため、設定により更新確認から除外
+                                // ※カクヨムの noveltype は登録時話数==1の推定値のため、短編除外は
+                                //   noveltype がAPI由来で確実なSyosetu作品にのみ適用する。
                                 val excludeShortUpdate = settingsStore.excludeShortFromUpdate.first()
                                 if (excludeShortUpdate) {
-                                    novelsForUpdate = novelsForUpdate.filter { it.noveltype != 2 }
+                                    novelsForUpdate = novelsForUpdate.filter {
+                                        it.site_type != NovelSiteAdapter.SITE_TYPE_SYOSETU || it.noveltype != 2
+                                    }
                                 }
                                 // 完結作品も設定により更新確認から除外（end_flag: 1=完結）
                                 val excludeCompletedUpdate = settingsStore.excludeCompletedFromUpdate.first()
@@ -603,7 +607,11 @@ fun UpdateInfoScreen(
                                                             Synopsis = updateSummary.novelDesc.Synopsis,
                                                             main_tag = updateSummary.novelDesc.main_tag,
                                                             sub_tag = updateSummary.novelDesc.sub_tag,
-                                                            last_update_date = updateSummary.novelDesc.last_update_date
+                                                            last_update_date = updateSummary.novelDesc.last_update_date,
+                                                            // 完結状態・作品種別は登録後も変化するため最新値で更新する
+                                                            // （end_flag: 完結除外フィルタ用 / noveltype: 1話のみ作品が連載化した際の短編誤判定の自己修復）
+                                                            end_flag = updateSummary.novelDesc.end_flag,
+                                                            noveltype = updateSummary.novelDesc.noveltype
                                                         )
                                                         repository.updateNovel(updatedNovel)
 

--- a/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
+++ b/Novel_reader/app/src/main/java/com/shunlight_library/novel_reader/worker/AutoUpdateWorker.kt
@@ -162,11 +162,14 @@ class AutoUpdateWorker(
                 // 更新対象の小説を取得（全ての小説）
                 val allNovels = repository.getNovelsForUpdate()
                 // 短編は新規エピソードが増えないため、設定により更新確認から除外
+                // ※カクヨムの noveltype は「登録時の話数==1」で短編判定する推定値のため、
+                //   1話だけの連載作品を恒久的に除外してしまう。短編除外は noveltype が
+                //   API由来で確実なSyosetu作品にのみ適用する。
                 val excludeShort = settingsStore.excludeShortFromUpdate.first()
                 // 完結作品も設定により更新確認から除外（end_flag: 1=完結）
                 val excludeCompleted = settingsStore.excludeCompletedFromUpdate.first()
                 val novels = allNovels.filter { novel ->
-                    (!excludeShort || novel.noveltype != 2) &&
+                    (!excludeShort || novel.site_type != NovelSiteAdapter.SITE_TYPE_SYOSETU || novel.noveltype != 2) &&
                     (!excludeCompleted || novel.end_flag != 1)
                 }
                 Log.d(TAG, "更新対象小説数: ${novels.size} (全${allNovels.size}件, 短編除外=$excludeShort, 完結除外=$excludeCompleted)")


### PR DESCRIPTION
## 概要
リリース前検証（v1.8.7→v2.0.18差分）で検出した、修正バッチ8〜10の更新確認フィルタ機能の実害不具合を修正し、v2.0.19へ。クラッシュ・データ損失はなし、ビルド成功・ユニットテスト93件パス。

## 修正内容
### 1. 短編除外をSyosetu限定に（高）
カクヨムの `noveltype` は「登録時の話数==1」で短編判定する推定値。短編除外（初期値ON）が、**1話だけの連載作品を恒久的に更新確認から除外**してしまっていた。`noveltype` がAPI由来で確実なSyosetu作品にのみ短編除外を適用するよう変更（`AutoUpdateWorker.kt` / `UpdateInfoScreen.kt`）。

### 2. カクヨム更新時に end_flag・noveltype を保存（高/中）
`fetchUpdateSummary` で取得した最新の完結状態・作品種別が `novel.copy()` で破棄されていた。最新値で保存するよう修正（完結除外フィルタの鮮度維持／1話作品が連載化した際の短編誤判定の自己修復）。

### 3. スキーマ 16.json の再生成（テスト基盤）
`16.json` が `17.json` と同一 identityHash の偽コピー（v16に存在しない `idx_image_cache_hash` を含む）だった。インデックス無しの正しいv16スキーマをRoom/KSPで再生成。`MIGRATION_16_17` 自体はv2.0.7でエンティティに宣言済みだったインデックスの不整合を解消する正当な修正であることを確認。

### 4. バージョン・ドキュメント
- 2.0.18 → 2.0.19 (versionCode 219)。連番スキップ(2.0.16)後の正常な+1。
- CLAUDE.md を v2.0.19 に更新、スキーマクイックリンクのアンカー修正。

## 検証
- `./gradlew :app:compileDebugKotlin :app:testDebugUnitTest` 成功（93件パス、失敗0）
- 17.json は再生成で不変（既に正しい）、16.json のみ更新

## 既知の残課題（フォローアップ）
- Syosetu の `end_flag` は登録後に更新されない（一括APIが `e` フィールド未取得、`updateEndFlag()` 未使用）。完結除外は初期値OFFのため影響は限定的。別途対応予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)